### PR TITLE
Add MusicBrainz integration and autocomplete for new song form

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -17,11 +17,24 @@ service cloud.firestore {
     match /carousels/{carouselId} {
       allow read: if true;
       allow write: if request.auth != null;
-      
+
     match /items/{itemId} {
         allow read: if true;
         allow write: if request.auth != null;
       }
+    }
+
+    // Popular music lookup collections (read-only, seeded via admin SDK)
+    match /popularArtists/{docId} {
+      allow read: if request.auth != null;
+    }
+
+    match /popularAlbums/{docId} {
+      allow read: if request.auth != null;
+    }
+
+    match /popularSongs/{docId} {
+      allow read: if request.auth != null;
     }
   }
 }

--- a/src/app/features/songs/new-song/new-song.component.html
+++ b/src/app/features/songs/new-song/new-song.component.html
@@ -11,15 +11,17 @@
       <!-- Title -->
       <div>
         <label for="title" class="block text-sm font-medium text-neutral-800 mb-1">Title</label>
-        <input
-          type="text"
-          id="title"
+        <p-autoComplete
+          inputId="title"
           formControlName="title"
+          [suggestions]="titleSuggestions"
+          (completeMethod)="searchTitles($event)"
+          [minQueryLength]="5"
+          [forceSelection]="false"
           placeholder="Song or exercise name"
-          pInputText
-          [attr.aria-invalid]="titleCtrl.invalid && (titleCtrl.touched || titleCtrl.dirty)"
-          class="w-full rounded-xl border border-neutral-300 bg-white text-neutral-900 placeholder:text-neutral-400 px-3 py-2
+          inputStyleClass="w-full rounded-xl border border-neutral-300 bg-white text-neutral-900 placeholder:text-neutral-400 px-3 py-2
                  focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
+          styleClass="w-full"
         />
         @if (titleCtrl.invalid && (titleCtrl.touched || titleCtrl.dirty)) {
           <div class="text-sm text-red-600 mt-1" aria-live="polite">Title is required.</div>
@@ -29,15 +31,17 @@
       <!-- Artist -->
       <div>
         <label for="artist" class="block text-sm font-medium text-neutral-800 mb-1">Artist</label>
-        <input
-          type="text"
-          id="artist"
+        <p-autoComplete
+          inputId="artist"
           formControlName="artist"
+          [suggestions]="artistSuggestions"
+          (completeMethod)="searchArtists($event)"
+          [minQueryLength]="5"
+          [forceSelection]="false"
           placeholder="Artist or composer"
-          pInputText
-          [attr.aria-invalid]="artistCtrl.invalid && (artistCtrl.touched || artistCtrl.dirty)"
-          class="w-full rounded-xl border border-neutral-300 bg-white text-neutral-900 placeholder:text-neutral-400 px-3 py-2
+          inputStyleClass="w-full rounded-xl border border-neutral-300 bg-white text-neutral-900 placeholder:text-neutral-400 px-3 py-2
                  focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
+          styleClass="w-full"
         />
         @if (artistCtrl.invalid && (artistCtrl.touched || artistCtrl.dirty)) {
           <div class="text-sm text-red-600 mt-1" aria-live="polite">Artist is required.</div>
@@ -47,14 +51,17 @@
       <!-- Album -->
       <div>
         <label for="album" class="block text-sm font-medium text-neutral-800 mb-1">Album</label>
-        <input
-          type="text"
-          id="album"
+        <p-autoComplete
+          inputId="album"
           formControlName="album"
+          [suggestions]="albumSuggestions"
+          (completeMethod)="searchAlbums($event)"
+          [minQueryLength]="5"
+          [forceSelection]="false"
           placeholder="Album name (optional)"
-          pInputText
-          class="w-full rounded-xl border border-neutral-300 bg-white text-neutral-900 placeholder:text-neutral-400 px-3 py-2
+          inputStyleClass="w-full rounded-xl border border-neutral-300 bg-white text-neutral-900 placeholder:text-neutral-400 px-3 py-2
                  focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
+          styleClass="w-full"
         />
       </div>
 

--- a/src/app/features/songs/new-song/new-song.component.ts
+++ b/src/app/features/songs/new-song/new-song.component.ts
@@ -3,21 +3,28 @@ import { CommonModule } from '@angular/common';
 import { FormBuilder, FormGroup, FormArray, ReactiveFormsModule, Validators } from '@angular/forms';
 import { Router } from '@angular/router';
 import { ButtonModule } from 'primeng/button';
+import { AutoComplete, AutoCompleteCompleteEvent } from 'primeng/autocomplete';
 import { SongsService } from '@services/songs.service';
+import { AutocompleteSuggestionService } from '@services/autocomplete-suggestion.service';
 
 @Component({
   selector: 'app-new-song',
   standalone: true,
-  imports: [CommonModule, ReactiveFormsModule, ButtonModule],
+  imports: [CommonModule, ReactiveFormsModule, ButtonModule, AutoComplete],
   templateUrl: './new-song.component.html',
 })
 export class NewSongComponent {
   private fb = inject(FormBuilder);
   private songsService = inject(SongsService);
   private router = inject(Router);
+  private suggestionSvc = inject(AutocompleteSuggestionService);
 
   private _saving = signal(false);
   saving = this._saving.asReadonly();
+
+  titleSuggestions: string[] = [];
+  artistSuggestions: string[] = [];
+  albumSuggestions: string[] = [];
 
   songForm: FormGroup = this.fb.group({
     title: ['', [Validators.required, Validators.minLength(1)]],
@@ -71,6 +78,24 @@ export class NewSongComponent {
       console.error('Error saving song:', error);
       this._saving.set(false);
     });
+  }
+
+  searchTitles(event: AutoCompleteCompleteEvent): void {
+    this.suggestionSvc.suggestTitles(event.query).subscribe(
+      results => this.titleSuggestions = results,
+    );
+  }
+
+  searchArtists(event: AutoCompleteCompleteEvent): void {
+    this.suggestionSvc.suggestArtists(event.query).subscribe(
+      results => this.artistSuggestions = results,
+    );
+  }
+
+  searchAlbums(event: AutoCompleteCompleteEvent): void {
+    this.suggestionSvc.suggestAlbums(event.query).subscribe(
+      results => this.albumSuggestions = results,
+    );
   }
 
   cancel(): void {

--- a/src/app/models/musicbrainz.ts
+++ b/src/app/models/musicbrainz.ts
@@ -1,0 +1,187 @@
+/** MusicBrainz API response types */
+
+// -- Shared primitives --
+
+export interface MbArtistCredit {
+  name: string;
+  artist: {
+    id: string;
+    name: string;
+    'sort-name': string;
+    disambiguation?: string;
+  };
+}
+
+export interface MbLifeSpan {
+  begin: string | null;
+  end: string | null;
+  ended: boolean;
+}
+
+export interface MbArea {
+  id: string;
+  name: string;
+  'sort-name': string;
+  'iso-3166-1-codes'?: string[];
+}
+
+export interface MbTag {
+  count: number;
+  name: string;
+}
+
+export interface MbAlias {
+  name: string;
+  'sort-name': string;
+  type: string | null;
+  locale: string | null;
+  primary: boolean | null;
+}
+
+// -- Artist --
+
+export interface MbArtist {
+  id: string;
+  type: string | null;
+  score?: number;
+  name: string;
+  'sort-name': string;
+  country?: string;
+  disambiguation?: string;
+  area?: MbArea;
+  'begin-area'?: MbArea;
+  'life-span'?: MbLifeSpan;
+  aliases?: MbAlias[];
+  tags?: MbTag[];
+  isnis?: string[];
+}
+
+export interface MbArtistSearchResponse {
+  created: string;
+  count: number;
+  offset: number;
+  artists: MbArtist[];
+}
+
+// -- Recording --
+
+export interface MbRecordingRelease {
+  id: string;
+  title: string;
+  status?: string;
+  date?: string;
+  country?: string;
+  'track-count'?: number;
+  'release-group'?: {
+    id: string;
+    title: string;
+    'primary-type'?: string;
+  };
+}
+
+export interface MbRecording {
+  id: string;
+  score?: number;
+  title: string;
+  length?: number;
+  'first-release-date'?: string;
+  'artist-credit'?: MbArtistCredit[];
+  releases?: MbRecordingRelease[];
+  tags?: MbTag[];
+}
+
+export interface MbRecordingSearchResponse {
+  created: string;
+  count: number;
+  offset: number;
+  recordings: MbRecording[];
+}
+
+// -- Release --
+
+export interface MbReleaseMedia {
+  format?: string;
+  'disc-count'?: number;
+  'track-count'?: number;
+}
+
+export interface MbRelease {
+  id: string;
+  score?: number;
+  title: string;
+  status?: string;
+  date?: string;
+  country?: string;
+  barcode?: string;
+  'track-count'?: number;
+  'artist-credit'?: MbArtistCredit[];
+  'release-group'?: {
+    id: string;
+    title: string;
+    'primary-type'?: string;
+  };
+  'release-events'?: Array<{
+    date?: string;
+    area?: MbArea;
+  }>;
+  'label-info'?: Array<{
+    'catalog-number'?: string;
+    label?: { id: string; name: string };
+  }>;
+  media?: MbReleaseMedia[];
+  'text-representation'?: {
+    language?: string;
+    script?: string;
+  };
+}
+
+export interface MbReleaseSearchResponse {
+  created: string;
+  count: number;
+  offset: number;
+  releases: MbRelease[];
+}
+
+// -- Genre --
+
+export interface MbGenre {
+  id: string;
+  name: string;
+  disambiguation?: string;
+}
+
+export interface MbGenreListResponse {
+  'genre-offset': number;
+  'genre-count': number;
+  genres: MbGenre[];
+}
+
+// -- Lookup responses (single entity with includes) --
+
+export interface MbArtistLookup extends MbArtist {
+  recordings?: MbRecording[];
+  releases?: MbRelease[];
+  'release-groups'?: Array<{
+    id: string;
+    title: string;
+    'primary-type'?: string;
+    'first-release-date'?: string;
+  }>;
+}
+
+export interface MbRecordingLookup extends MbRecording {
+  isrcs?: string[];
+}
+
+export interface MbReleaseLookup extends MbRelease {
+  media?: Array<MbReleaseMedia & {
+    tracks?: Array<{
+      id: string;
+      number: string;
+      title: string;
+      length?: number;
+      position: number;
+      recording?: MbRecording;
+    }>;
+  }>;
+}

--- a/src/app/models/popular-music.ts
+++ b/src/app/models/popular-music.ts
@@ -1,0 +1,19 @@
+export interface PopularArtist {
+  id?: string;
+  name: string;
+  sortName: string;
+}
+
+export interface PopularAlbum {
+  id?: string;
+  title: string;
+  artist: string;
+  sortTitle: string;
+}
+
+export interface PopularSong {
+  id?: string;
+  title: string;
+  artist: string;
+  sortTitle: string;
+}

--- a/src/app/services/autocomplete-suggestion.service.spec.ts
+++ b/src/app/services/autocomplete-suggestion.service.spec.ts
@@ -1,0 +1,157 @@
+import { TestBed } from '@angular/core/testing';
+import { of, throwError, firstValueFrom } from 'rxjs';
+import { AutocompleteSuggestionService } from './autocomplete-suggestion.service';
+import { PopularMusicService } from './popular-music.service';
+import { MusicbrainzService } from './musicbrainz.service';
+
+describe('AutocompleteSuggestionService', () => {
+  let service: AutocompleteSuggestionService;
+
+  const popularMock: any = {
+    searchArtists: jest.fn(() => of([])),
+    searchAlbums: jest.fn(() => of([])),
+    searchSongs: jest.fn(() => of([])),
+  };
+
+  const mbMock: any = {
+    searchArtists: jest.fn(() => of({ artists: [] })),
+    searchRecordings: jest.fn(() => of({ recordings: [] })),
+    searchReleases: jest.fn(() => of({ releases: [] })),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    TestBed.configureTestingModule({
+      providers: [
+        AutocompleteSuggestionService,
+        { provide: PopularMusicService, useValue: popularMock },
+        { provide: MusicbrainzService, useValue: mbMock },
+      ],
+    });
+    service = TestBed.inject(AutocompleteSuggestionService);
+  });
+
+  // ───── suggestArtists ─────
+
+  it('returns local results only when >= 3 matches (no MusicBrainz call)', async () => {
+    popularMock.searchArtists.mockReturnValue(of(['The Beatles', 'The Rolling Stones', 'The Who']));
+
+    const results = await firstValueFrom(service.suggestArtists('the'));
+
+    expect(results).toEqual(['The Beatles', 'The Rolling Stones', 'The Who']);
+    expect(mbMock.searchArtists).not.toHaveBeenCalled();
+  });
+
+  it('falls back to MusicBrainz when local results < 3', async () => {
+    popularMock.searchArtists.mockReturnValue(of(['Radiohead']));
+    mbMock.searchArtists.mockReturnValue(of({
+      artists: [{ name: 'Radiohead' }, { name: 'Radio Moscow' }],
+    }));
+
+    const results = await firstValueFrom(service.suggestArtists('radio'));
+
+    expect(mbMock.searchArtists).toHaveBeenCalledWith('radio', 5);
+    expect(results).toContain('Radiohead');
+    expect(results).toContain('Radio Moscow');
+  });
+
+  it('deduplicates results case-insensitively', async () => {
+    popularMock.searchArtists.mockReturnValue(of(['The Beatles']));
+    mbMock.searchArtists.mockReturnValue(of({
+      artists: [{ name: 'the beatles' }, { name: 'Beatles Revival' }],
+    }));
+
+    const results = await firstValueFrom(service.suggestArtists('beatl'));
+
+    // "The Beatles" from local and "the beatles" from MB should collapse to one
+    const beatlesCount = results.filter(r => r.toLowerCase() === 'the beatles').length;
+    expect(beatlesCount).toBe(1);
+    expect(results).toContain('Beatles Revival');
+  });
+
+  it('handles MusicBrainz error gracefully (returns local only)', async () => {
+    popularMock.searchArtists.mockReturnValue(of(['Pink Floyd']));
+    mbMock.searchArtists.mockReturnValue(throwError(() => new Error('503')));
+
+    const results = await firstValueFrom(service.suggestArtists('pink'));
+
+    expect(results).toEqual(['Pink Floyd']);
+  });
+
+  // ───── suggestTitles ─────
+
+  it('returns local song results when >= 3 matches', async () => {
+    popularMock.searchSongs.mockReturnValue(of(['Blackbird', 'Black Dog', 'Back in Black']));
+
+    const results = await firstValueFrom(service.suggestTitles('bla'));
+
+    expect(results).toEqual(['Blackbird', 'Black Dog', 'Back in Black']);
+    expect(mbMock.searchRecordings).not.toHaveBeenCalled();
+  });
+
+  it('falls back to MusicBrainz recordings when local < 3', async () => {
+    popularMock.searchSongs.mockReturnValue(of(['Yesterday']));
+    mbMock.searchRecordings.mockReturnValue(of({
+      recordings: [{ title: 'Yesterday' }, { title: 'Yesterday Once More' }],
+    }));
+
+    const results = await firstValueFrom(service.suggestTitles('yester'));
+
+    expect(mbMock.searchRecordings).toHaveBeenCalledWith('yester', 5);
+    expect(results).toContain('Yesterday');
+    expect(results).toContain('Yesterday Once More');
+  });
+
+  it('handles MusicBrainz recording error gracefully', async () => {
+    popularMock.searchSongs.mockReturnValue(of(['Creep']));
+    mbMock.searchRecordings.mockReturnValue(throwError(() => new Error('timeout')));
+
+    const results = await firstValueFrom(service.suggestTitles('cre'));
+
+    expect(results).toEqual(['Creep']);
+  });
+
+  // ───── suggestAlbums ─────
+
+  it('returns local album results when >= 3 matches', async () => {
+    popularMock.searchAlbums.mockReturnValue(of(['Abbey Road', 'A Night at the Opera', 'Ah Via Musicom']));
+
+    const results = await firstValueFrom(service.suggestAlbums('a'));
+
+    expect(results).toEqual(['Abbey Road', 'A Night at the Opera', 'Ah Via Musicom']);
+    expect(mbMock.searchReleases).not.toHaveBeenCalled();
+  });
+
+  it('falls back to MusicBrainz releases when local < 3', async () => {
+    popularMock.searchAlbums.mockReturnValue(of(['Rumours']));
+    mbMock.searchReleases.mockReturnValue(of({
+      releases: [{ title: 'Rumours' }, { title: 'Rumours (Deluxe)' }],
+    }));
+
+    const results = await firstValueFrom(service.suggestAlbums('rum'));
+
+    expect(mbMock.searchReleases).toHaveBeenCalledWith('rum', 5);
+    expect(results).toContain('Rumours');
+    expect(results).toContain('Rumours (Deluxe)');
+  });
+
+  it('handles MusicBrainz release error gracefully', async () => {
+    popularMock.searchAlbums.mockReturnValue(of([]));
+    mbMock.searchReleases.mockReturnValue(throwError(() => new Error('network')));
+
+    const results = await firstValueFrom(service.suggestAlbums('zzz'));
+
+    expect(results).toEqual([]);
+  });
+
+  // ───── Edge cases ─────
+
+  it('returns empty when both sources return nothing', async () => {
+    popularMock.searchArtists.mockReturnValue(of([]));
+    mbMock.searchArtists.mockReturnValue(of({ artists: [] }));
+
+    const results = await firstValueFrom(service.suggestArtists('xyznonexistent'));
+
+    expect(results).toEqual([]);
+  });
+});

--- a/src/app/services/autocomplete-suggestion.service.ts
+++ b/src/app/services/autocomplete-suggestion.service.ts
@@ -1,0 +1,69 @@
+import { Injectable, inject } from '@angular/core';
+import { Observable, of } from 'rxjs';
+import { map, switchMap, catchError } from 'rxjs/operators';
+import { PopularMusicService } from './popular-music.service';
+import { MusicbrainzService } from './musicbrainz.service';
+
+const LOCAL_THRESHOLD = 3;
+const MB_LIMIT = 5;
+
+@Injectable({ providedIn: 'root' })
+export class AutocompleteSuggestionService {
+  private popular = inject(PopularMusicService);
+  private mb = inject(MusicbrainzService);
+
+  suggestArtists(query: string): Observable<string[]> {
+    return this.popular.searchArtists(query).pipe(
+      switchMap(localResults => {
+        if (localResults.length >= LOCAL_THRESHOLD) {
+          return of(localResults);
+        }
+        return this.mb.searchArtists(query, MB_LIMIT).pipe(
+          map(res => res.artists.map(a => a.name)),
+          catchError(() => of([])),
+          map(mbResults => this.dedup([...localResults, ...mbResults])),
+        );
+      }),
+    );
+  }
+
+  suggestTitles(query: string): Observable<string[]> {
+    return this.popular.searchSongs(query).pipe(
+      switchMap(localResults => {
+        if (localResults.length >= LOCAL_THRESHOLD) {
+          return of(localResults);
+        }
+        return this.mb.searchRecordings(query, MB_LIMIT).pipe(
+          map(res => res.recordings.map(r => r.title)),
+          catchError(() => of([])),
+          map(mbResults => this.dedup([...localResults, ...mbResults])),
+        );
+      }),
+    );
+  }
+
+  suggestAlbums(query: string): Observable<string[]> {
+    return this.popular.searchAlbums(query).pipe(
+      switchMap(localResults => {
+        if (localResults.length >= LOCAL_THRESHOLD) {
+          return of(localResults);
+        }
+        return this.mb.searchReleases(query, MB_LIMIT).pipe(
+          map(res => res.releases.map(r => r.title)),
+          catchError(() => of([])),
+          map(mbResults => this.dedup([...localResults, ...mbResults])),
+        );
+      }),
+    );
+  }
+
+  private dedup(items: string[]): string[] {
+    const seen = new Set<string>();
+    return items.filter(item => {
+      const key = item.toLowerCase();
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    });
+  }
+}

--- a/src/app/services/musicbrainz.service.spec.ts
+++ b/src/app/services/musicbrainz.service.spec.ts
@@ -1,0 +1,241 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { MusicbrainzService } from './musicbrainz.service';
+import type {
+  MbArtistSearchResponse,
+  MbArtistLookup,
+  MbRecordingSearchResponse,
+  MbRecordingLookup,
+  MbReleaseSearchResponse,
+  MbReleaseLookup,
+  MbGenreListResponse,
+  MbGenre,
+} from '@models/musicbrainz';
+
+const API = 'https://musicbrainz.org/ws/2';
+
+describe('MusicbrainzService', () => {
+  let service: MusicbrainzService;
+  let httpTesting: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideHttpClient(), provideHttpClientTesting()],
+    });
+    service = TestBed.inject(MusicbrainzService);
+    httpTesting = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpTesting.verify();
+  });
+
+  // ───── searchArtists ─────
+
+  it('sends a GET to /artist with query, fmt, limit, offset', () => {
+    const stub: MbArtistSearchResponse = { created: '', count: 1, offset: 0, artists: [] };
+    service.searchArtists('beatles').subscribe(res => {
+      expect(res).toEqual(stub);
+    });
+
+    const req = httpTesting.expectOne(r =>
+      r.url === `${API}/artist` && r.params.get('query') === 'beatles'
+    );
+    expect(req.request.method).toBe('GET');
+    expect(req.request.params.get('fmt')).toBe('json');
+    expect(req.request.params.get('limit')).toBe('25');
+    expect(req.request.params.get('offset')).toBe('0');
+    req.flush(stub);
+  });
+
+  it('searchArtists respects custom limit and offset', () => {
+    service.searchArtists('pink floyd', 10, 50).subscribe();
+    const req = httpTesting.expectOne(r => r.url === `${API}/artist`);
+    expect(req.request.params.get('limit')).toBe('10');
+    expect(req.request.params.get('offset')).toBe('50');
+    req.flush({ created: '', count: 0, offset: 50, artists: [] });
+  });
+
+  it('searchArtists includes User-Agent header', () => {
+    service.searchArtists('queen').subscribe();
+    const req = httpTesting.expectOne(r => r.url === `${API}/artist`);
+    expect(req.request.headers.get('User-Agent')).toContain('GuitarJourney');
+    req.flush({ created: '', count: 0, offset: 0, artists: [] });
+  });
+
+  // ───── lookupArtist ─────
+
+  it('sends a GET to /artist/<mbid> with fmt=json', () => {
+    const mbid = 'b10bbbfc-cf9e-42e0-be17-e2c3e1d2600d';
+    const stub: MbArtistLookup = { id: mbid, name: 'The Beatles', 'sort-name': 'Beatles, The', type: 'Group' };
+    service.lookupArtist(mbid).subscribe(res => {
+      expect(res).toEqual(stub);
+    });
+
+    const req = httpTesting.expectOne(r => r.url === `${API}/artist/${mbid}`);
+    expect(req.request.method).toBe('GET');
+    expect(req.request.params.get('fmt')).toBe('json');
+    expect(req.request.params.has('inc')).toBe(false);
+    req.flush(stub);
+  });
+
+  it('lookupArtist appends inc when provided', () => {
+    const mbid = 'abc-123';
+    service.lookupArtist(mbid, ['recordings', 'releases']).subscribe();
+    const req = httpTesting.expectOne(r => r.url === `${API}/artist/${mbid}`);
+    expect(req.request.params.get('inc')).toBe('recordings+releases');
+    req.flush({ id: mbid, name: 'X', 'sort-name': 'X', type: null });
+  });
+
+  // ───── searchRecordings ─────
+
+  it('sends a GET to /recording with query params', () => {
+    const stub: MbRecordingSearchResponse = { created: '', count: 5, offset: 0, recordings: [] };
+    service.searchRecordings('yesterday').subscribe(res => {
+      expect(res).toEqual(stub);
+    });
+
+    const req = httpTesting.expectOne(r =>
+      r.url === `${API}/recording` && r.params.get('query') === 'yesterday'
+    );
+    expect(req.request.method).toBe('GET');
+    expect(req.request.params.get('fmt')).toBe('json');
+    req.flush(stub);
+  });
+
+  it('searchRecordings respects custom limit and offset', () => {
+    service.searchRecordings('stairway', 5, 20).subscribe();
+    const req = httpTesting.expectOne(r => r.url === `${API}/recording`);
+    expect(req.request.params.get('limit')).toBe('5');
+    expect(req.request.params.get('offset')).toBe('20');
+    req.flush({ created: '', count: 0, offset: 20, recordings: [] });
+  });
+
+  // ───── lookupRecording ─────
+
+  it('sends a GET to /recording/<mbid>', () => {
+    const mbid = 'rec-001';
+    const stub: MbRecordingLookup = { id: mbid, title: 'Yesterday', length: 125000 };
+    service.lookupRecording(mbid).subscribe(res => {
+      expect(res).toEqual(stub);
+    });
+
+    const req = httpTesting.expectOne(r => r.url === `${API}/recording/${mbid}`);
+    expect(req.request.method).toBe('GET');
+    expect(req.request.params.get('fmt')).toBe('json');
+    req.flush(stub);
+  });
+
+  it('lookupRecording appends inc when provided', () => {
+    const mbid = 'rec-002';
+    service.lookupRecording(mbid, ['releases']).subscribe();
+    const req = httpTesting.expectOne(r => r.url === `${API}/recording/${mbid}`);
+    expect(req.request.params.get('inc')).toBe('releases');
+    req.flush({ id: mbid, title: 'X' });
+  });
+
+  // ───── searchReleases ─────
+
+  it('sends a GET to /release with query params', () => {
+    const stub: MbReleaseSearchResponse = { created: '', count: 3, offset: 0, releases: [] };
+    service.searchReleases('abbey road').subscribe(res => {
+      expect(res).toEqual(stub);
+    });
+
+    const req = httpTesting.expectOne(r =>
+      r.url === `${API}/release` && r.params.get('query') === 'abbey road'
+    );
+    expect(req.request.method).toBe('GET');
+    req.flush(stub);
+  });
+
+  it('searchReleases respects custom limit and offset', () => {
+    service.searchReleases('thriller', 15, 30).subscribe();
+    const req = httpTesting.expectOne(r => r.url === `${API}/release`);
+    expect(req.request.params.get('limit')).toBe('15');
+    expect(req.request.params.get('offset')).toBe('30');
+    req.flush({ created: '', count: 0, offset: 30, releases: [] });
+  });
+
+  // ───── lookupRelease ─────
+
+  it('sends a GET to /release/<mbid>', () => {
+    const mbid = 'rel-001';
+    const stub: MbReleaseLookup = { id: mbid, title: 'Abbey Road', status: 'Official' };
+    service.lookupRelease(mbid).subscribe(res => {
+      expect(res).toEqual(stub);
+    });
+
+    const req = httpTesting.expectOne(r => r.url === `${API}/release/${mbid}`);
+    expect(req.request.method).toBe('GET');
+    req.flush(stub);
+  });
+
+  it('lookupRelease appends inc when provided', () => {
+    const mbid = 'rel-002';
+    service.lookupRelease(mbid, ['recordings', 'labels']).subscribe();
+    const req = httpTesting.expectOne(r => r.url === `${API}/release/${mbid}`);
+    expect(req.request.params.get('inc')).toBe('recordings+labels');
+    req.flush({ id: mbid, title: 'X' });
+  });
+
+  // ───── listGenres ─────
+
+  it('sends a GET to /genre/all with default limit=100', () => {
+    const stub: MbGenreListResponse = { 'genre-offset': 0, 'genre-count': 2119, genres: [] };
+    service.listGenres().subscribe(res => {
+      expect(res).toEqual(stub);
+    });
+
+    const req = httpTesting.expectOne(r => r.url === `${API}/genre/all`);
+    expect(req.request.method).toBe('GET');
+    expect(req.request.params.get('fmt')).toBe('json');
+    expect(req.request.params.get('limit')).toBe('100');
+    expect(req.request.params.get('offset')).toBe('0');
+    req.flush(stub);
+  });
+
+  it('listGenres respects custom limit and offset', () => {
+    service.listGenres(50, 200).subscribe();
+    const req = httpTesting.expectOne(r => r.url === `${API}/genre/all`);
+    expect(req.request.params.get('limit')).toBe('50');
+    expect(req.request.params.get('offset')).toBe('200');
+    req.flush({ 'genre-offset': 200, 'genre-count': 2119, genres: [] });
+  });
+
+  it('listGenres includes User-Agent header', () => {
+    service.listGenres().subscribe();
+    const req = httpTesting.expectOne(r => r.url === `${API}/genre/all`);
+    expect(req.request.headers.get('User-Agent')).toContain('GuitarJourney');
+    req.flush({ 'genre-offset': 0, 'genre-count': 0, genres: [] });
+  });
+
+  // ───── lookupGenre ─────
+
+  it('sends a GET to /genre/<mbid>', () => {
+    const mbid = 'genre-001';
+    const stub: MbGenre = { id: mbid, name: 'Rock' };
+    service.lookupGenre(mbid).subscribe(res => {
+      expect(res).toEqual(stub);
+    });
+
+    const req = httpTesting.expectOne(r => r.url === `${API}/genre/${mbid}`);
+    expect(req.request.method).toBe('GET');
+    expect(req.request.params.get('fmt')).toBe('json');
+    req.flush(stub);
+  });
+
+  // ───── Error handling ─────
+
+  it('propagates HTTP errors to the subscriber', () => {
+    service.searchArtists('nonexistent').subscribe({
+      error: err => {
+        expect(err.status).toBe(503);
+      },
+    });
+
+    const req = httpTesting.expectOne(r => r.url === `${API}/artist`);
+    req.flush('Service Unavailable', { status: 503, statusText: 'Service Unavailable' });
+  });
+});

--- a/src/app/services/musicbrainz.service.ts
+++ b/src/app/services/musicbrainz.service.ts
@@ -1,0 +1,109 @@
+import { Injectable } from '@angular/core';
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import {
+  MbArtistSearchResponse,
+  MbArtistLookup,
+  MbRecordingSearchResponse,
+  MbRecordingLookup,
+  MbReleaseSearchResponse,
+  MbReleaseLookup,
+  MbGenreListResponse,
+  MbGenre,
+} from '@models/musicbrainz';
+
+const API_BASE = 'https://musicbrainz.org/ws/2';
+const USER_AGENT = 'GuitarJourney/0.5.0 (https://github.com/FatherOfCurses/guitarJourney)';
+const DEFAULT_LIMIT = 25;
+
+@Injectable({ providedIn: 'root' })
+export class MusicbrainzService {
+  constructor(private http: HttpClient) {}
+
+  // ───── Artist ─────
+
+  /** Full-text search for artists. Uses Lucene query syntax. */
+  searchArtists(query: string, limit = DEFAULT_LIMIT, offset = 0): Observable<MbArtistSearchResponse> {
+    return this.search<MbArtistSearchResponse>('artist', query, limit, offset);
+  }
+
+  /** Lookup a single artist by MBID. Optionally include sub-resources. */
+  lookupArtist(mbid: string, inc: string[] = []): Observable<MbArtistLookup> {
+    return this.lookup<MbArtistLookup>('artist', mbid, inc);
+  }
+
+  // ───── Recording ─────
+
+  /** Full-text search for recordings. */
+  searchRecordings(query: string, limit = DEFAULT_LIMIT, offset = 0): Observable<MbRecordingSearchResponse> {
+    return this.search<MbRecordingSearchResponse>('recording', query, limit, offset);
+  }
+
+  /** Lookup a single recording by MBID. */
+  lookupRecording(mbid: string, inc: string[] = []): Observable<MbRecordingLookup> {
+    return this.lookup<MbRecordingLookup>('recording', mbid, inc);
+  }
+
+  // ───── Release ─────
+
+  /** Full-text search for releases. */
+  searchReleases(query: string, limit = DEFAULT_LIMIT, offset = 0): Observable<MbReleaseSearchResponse> {
+    return this.search<MbReleaseSearchResponse>('release', query, limit, offset);
+  }
+
+  /** Lookup a single release by MBID. */
+  lookupRelease(mbid: string, inc: string[] = []): Observable<MbReleaseLookup> {
+    return this.lookup<MbReleaseLookup>('release', mbid, inc);
+  }
+
+  // ───── Genre ─────
+
+  /** List all MusicBrainz genres (paginated). */
+  listGenres(limit = 100, offset = 0): Observable<MbGenreListResponse> {
+    const params = new HttpParams()
+      .set('fmt', 'json')
+      .set('limit', limit)
+      .set('offset', offset);
+
+    return this.http.get<MbGenreListResponse>(`${API_BASE}/genre/all`, {
+      params,
+      headers: { 'User-Agent': USER_AGENT },
+    });
+  }
+
+  /** Lookup a single genre by MBID. */
+  lookupGenre(mbid: string): Observable<MbGenre> {
+    const params = new HttpParams().set('fmt', 'json');
+    return this.http.get<MbGenre>(`${API_BASE}/genre/${encodeURIComponent(mbid)}`, {
+      params,
+      headers: { 'User-Agent': USER_AGENT },
+    });
+  }
+
+  // ───── Internals ─────
+
+  private search<T>(entity: string, query: string, limit: number, offset: number): Observable<T> {
+    const params = new HttpParams()
+      .set('query', query)
+      .set('fmt', 'json')
+      .set('limit', limit)
+      .set('offset', offset);
+
+    return this.http.get<T>(`${API_BASE}/${entity}`, {
+      params,
+      headers: { 'User-Agent': USER_AGENT },
+    });
+  }
+
+  private lookup<T>(entity: string, mbid: string, inc: string[]): Observable<T> {
+    let params = new HttpParams().set('fmt', 'json');
+    if (inc.length) {
+      params = params.set('inc', inc.join('+'));
+    }
+
+    return this.http.get<T>(`${API_BASE}/${entity}/${encodeURIComponent(mbid)}`, {
+      params,
+      headers: { 'User-Agent': USER_AGENT },
+    });
+  }
+}

--- a/src/app/services/popular-music.service.spec.ts
+++ b/src/app/services/popular-music.service.spec.ts
@@ -1,0 +1,122 @@
+jest.mock('@angular/fire/firestore', () => ({
+  Firestore: class {},
+  collection: jest.fn(),
+  query: jest.fn(),
+  where: jest.fn(),
+  orderBy: jest.fn(),
+  limit: jest.fn(),
+  getDocs: jest.fn(),
+}));
+
+import { TestBed } from '@angular/core/testing';
+import { firstValueFrom } from 'rxjs';
+import * as afs from '@angular/fire/firestore';
+import { PopularMusicService } from './popular-music.service';
+
+describe('PopularMusicService', () => {
+  let service: PopularMusicService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        PopularMusicService,
+        { provide: (afs as any).Firestore, useValue: {} },
+      ],
+    });
+    service = TestBed.inject(PopularMusicService);
+    jest.clearAllMocks();
+
+    (afs.collection as jest.Mock).mockImplementation(() => ({
+      withConverter: () => ({ __type: 'CollectionRefWithConverter' }),
+    }));
+    (afs.query as jest.Mock).mockReturnValue({ __type: 'Query' });
+    (afs.where as jest.Mock).mockReturnValue({});
+    (afs.orderBy as jest.Mock).mockReturnValue({});
+    (afs.limit as jest.Mock).mockReturnValue({});
+  });
+
+  afterEach(() => jest.restoreAllMocks());
+
+  // ───── searchArtists ─────
+
+  it('searchArtists queries the popularArtists collection', async () => {
+    (afs.getDocs as jest.Mock).mockResolvedValue({
+      docs: [{ data: () => ({ name: 'The Beatles', sortName: 'the beatles' }) }],
+    });
+
+    const results = await firstValueFrom(service.searchArtists('the'));
+
+    expect(afs.collection).toHaveBeenCalledWith(expect.anything(), 'popularArtists');
+    expect(results).toEqual(['The Beatles']);
+  });
+
+  it('searchArtists uses prefix range with where clauses', async () => {
+    (afs.getDocs as jest.Mock).mockResolvedValue({ docs: [] });
+
+    await firstValueFrom(service.searchArtists('Bea'));
+
+    expect(afs.where).toHaveBeenCalledWith('sortName', '>=', 'bea');
+    expect(afs.where).toHaveBeenCalledWith('sortName', '<', 'bea\uf8ff');
+    expect(afs.orderBy).toHaveBeenCalledWith('sortName');
+  });
+
+  it('searchArtists respects maxResults via limit', async () => {
+    (afs.getDocs as jest.Mock).mockResolvedValue({ docs: [] });
+
+    await firstValueFrom(service.searchArtists('z', 5));
+
+    expect(afs.limit).toHaveBeenCalledWith(5);
+  });
+
+  it('searchArtists returns empty array when no matches', async () => {
+    (afs.getDocs as jest.Mock).mockResolvedValue({ docs: [] });
+
+    const results = await firstValueFrom(service.searchArtists('zzz'));
+
+    expect(results).toEqual([]);
+  });
+
+  // ───── searchAlbums ─────
+
+  it('searchAlbums queries the popularAlbums collection', async () => {
+    (afs.getDocs as jest.Mock).mockResolvedValue({
+      docs: [{ data: () => ({ title: 'Abbey Road', artist: 'The Beatles', sortTitle: 'abbey road' }) }],
+    });
+
+    const results = await firstValueFrom(service.searchAlbums('abb'));
+
+    expect(afs.collection).toHaveBeenCalledWith(expect.anything(), 'popularAlbums');
+    expect(results).toEqual(['Abbey Road']);
+  });
+
+  it('searchAlbums uses sortTitle for prefix range', async () => {
+    (afs.getDocs as jest.Mock).mockResolvedValue({ docs: [] });
+
+    await firstValueFrom(service.searchAlbums('Dark'));
+
+    expect(afs.where).toHaveBeenCalledWith('sortTitle', '>=', 'dark');
+    expect(afs.where).toHaveBeenCalledWith('sortTitle', '<', 'dark\uf8ff');
+  });
+
+  // ───── searchSongs ─────
+
+  it('searchSongs queries the popularSongs collection', async () => {
+    (afs.getDocs as jest.Mock).mockResolvedValue({
+      docs: [{ data: () => ({ title: 'Stairway to Heaven', artist: 'Led Zeppelin', sortTitle: 'stairway to heaven' }) }],
+    });
+
+    const results = await firstValueFrom(service.searchSongs('stair'));
+
+    expect(afs.collection).toHaveBeenCalledWith(expect.anything(), 'popularSongs');
+    expect(results).toEqual(['Stairway to Heaven']);
+  });
+
+  it('searchSongs uses sortTitle for prefix range', async () => {
+    (afs.getDocs as jest.Mock).mockResolvedValue({ docs: [] });
+
+    await firstValueFrom(service.searchSongs('Hotel'));
+
+    expect(afs.where).toHaveBeenCalledWith('sortTitle', '>=', 'hotel');
+    expect(afs.where).toHaveBeenCalledWith('sortTitle', '<', 'hotel\uf8ff');
+  });
+});

--- a/src/app/services/popular-music.service.ts
+++ b/src/app/services/popular-music.service.ts
@@ -1,0 +1,62 @@
+import { Injectable, inject } from '@angular/core';
+import {
+  Firestore,
+  collection,
+  query,
+  where,
+  orderBy,
+  limit,
+  getDocs,
+} from '@angular/fire/firestore';
+import { from, Observable, map } from 'rxjs';
+import { popularArtistConverter, popularAlbumConverter, popularSongConverter } from '../storage/popular-music.converters';
+
+@Injectable({ providedIn: 'root' })
+export class PopularMusicService {
+  private firestore = inject(Firestore);
+
+  searchArtists(prefix: string, maxResults = 10): Observable<string[]> {
+    const lower = prefix.toLowerCase();
+    const col = collection(this.firestore, 'popularArtists').withConverter(popularArtistConverter);
+    const q = query(
+      col,
+      where('sortName', '>=', lower),
+      where('sortName', '<', lower + '\uf8ff'),
+      orderBy('sortName'),
+      limit(maxResults),
+    );
+    return from(getDocs(q)).pipe(
+      map(snap => snap.docs.map(d => d.data().name as string)),
+    );
+  }
+
+  searchAlbums(prefix: string, maxResults = 10): Observable<string[]> {
+    const lower = prefix.toLowerCase();
+    const col = collection(this.firestore, 'popularAlbums').withConverter(popularAlbumConverter);
+    const q = query(
+      col,
+      where('sortTitle', '>=', lower),
+      where('sortTitle', '<', lower + '\uf8ff'),
+      orderBy('sortTitle'),
+      limit(maxResults),
+    );
+    return from(getDocs(q)).pipe(
+      map(snap => snap.docs.map(d => d.data().title as string)),
+    );
+  }
+
+  searchSongs(prefix: string, maxResults = 10): Observable<string[]> {
+    const lower = prefix.toLowerCase();
+    const col = collection(this.firestore, 'popularSongs').withConverter(popularSongConverter);
+    const q = query(
+      col,
+      where('sortTitle', '>=', lower),
+      where('sortTitle', '<', lower + '\uf8ff'),
+      orderBy('sortTitle'),
+      limit(maxResults),
+    );
+    return from(getDocs(q)).pipe(
+      map(snap => snap.docs.map(d => d.data().title as string)),
+    );
+  }
+}

--- a/src/app/storage/firestore.rules
+++ b/src/app/storage/firestore.rules
@@ -34,6 +34,19 @@ service cloud.firestore {
       allow update, delete: if isOwnerOnExisting();
     }
 
+    // Popular music lookup collections (read-only, seeded via admin SDK)
+    match /popularArtists/{docId} {
+      allow read: if isSignedIn();
+    }
+
+    match /popularAlbums/{docId} {
+      allow read: if isSignedIn();
+    }
+
+    match /popularSongs/{docId} {
+      allow read: if isSignedIn();
+    }
+
     // Optional: user-owned documents metadata if you store file metadata in Firestore
     match /users/{uid}/documents/{docId} {
       allow read: if isOwner(uid);

--- a/src/app/storage/popular-music.converters.spec.ts
+++ b/src/app/storage/popular-music.converters.spec.ts
@@ -1,0 +1,53 @@
+import {
+  popularArtistConverter,
+  popularAlbumConverter,
+  popularSongConverter,
+} from './popular-music.converters';
+import type { PopularArtist, PopularAlbum, PopularSong } from '../models/popular-music';
+
+describe('Popular music converters', () => {
+  describe('popularArtistConverter', () => {
+    it('toFirestore lowercases sortName and omits id', () => {
+      const artist: PopularArtist = { name: 'The Beatles', sortName: 'The Beatles' };
+      const doc = popularArtistConverter.toFirestore(artist);
+      expect(doc).toEqual({ name: 'The Beatles', sortName: 'the beatles' });
+      expect('id' in (doc as any)).toBe(false);
+    });
+
+    it('fromFirestore returns { id, ...data }', () => {
+      const snap = { id: 'the-beatles', data: () => ({ name: 'The Beatles', sortName: 'the beatles' }) } as any;
+      const result = popularArtistConverter.fromFirestore(snap);
+      expect(result).toEqual({ id: 'the-beatles', name: 'The Beatles', sortName: 'the beatles' });
+    });
+  });
+
+  describe('popularAlbumConverter', () => {
+    it('toFirestore lowercases sortTitle and omits id', () => {
+      const album: PopularAlbum = { title: 'Abbey Road', artist: 'The Beatles', sortTitle: 'Abbey Road' };
+      const doc = popularAlbumConverter.toFirestore(album);
+      expect(doc).toEqual({ title: 'Abbey Road', artist: 'The Beatles', sortTitle: 'abbey road' });
+      expect('id' in (doc as any)).toBe(false);
+    });
+
+    it('fromFirestore returns { id, ...data }', () => {
+      const snap = { id: 'abbey-road', data: () => ({ title: 'Abbey Road', artist: 'The Beatles', sortTitle: 'abbey road' }) } as any;
+      const result = popularAlbumConverter.fromFirestore(snap);
+      expect(result).toEqual({ id: 'abbey-road', title: 'Abbey Road', artist: 'The Beatles', sortTitle: 'abbey road' });
+    });
+  });
+
+  describe('popularSongConverter', () => {
+    it('toFirestore lowercases sortTitle and omits id', () => {
+      const song: PopularSong = { title: 'Blackbird', artist: 'The Beatles', sortTitle: 'Blackbird' };
+      const doc = popularSongConverter.toFirestore(song);
+      expect(doc).toEqual({ title: 'Blackbird', artist: 'The Beatles', sortTitle: 'blackbird' });
+      expect('id' in (doc as any)).toBe(false);
+    });
+
+    it('fromFirestore returns { id, ...data }', () => {
+      const snap = { id: 'blackbird', data: () => ({ title: 'Blackbird', artist: 'The Beatles', sortTitle: 'blackbird' }) } as any;
+      const result = popularSongConverter.fromFirestore(snap);
+      expect(result).toEqual({ id: 'blackbird', title: 'Blackbird', artist: 'The Beatles', sortTitle: 'blackbird' });
+    });
+  });
+});

--- a/src/app/storage/popular-music.converters.ts
+++ b/src/app/storage/popular-music.converters.ts
@@ -1,0 +1,28 @@
+import { FirestoreDataConverter } from 'firebase/firestore';
+import { PopularArtist, PopularAlbum, PopularSong } from '../models/popular-music';
+
+export const popularArtistConverter: FirestoreDataConverter<PopularArtist> = {
+  toFirestore: (a) => ({
+    name: a.name,
+    sortName: (a.sortName ?? a.name).toLowerCase(),
+  }),
+  fromFirestore: (snap) => ({ id: snap.id, ...snap.data() } as PopularArtist),
+};
+
+export const popularAlbumConverter: FirestoreDataConverter<PopularAlbum> = {
+  toFirestore: (a) => ({
+    title: a.title,
+    artist: a.artist,
+    sortTitle: (a.sortTitle ?? a.title).toLowerCase(),
+  }),
+  fromFirestore: (snap) => ({ id: snap.id, ...snap.data() } as PopularAlbum),
+};
+
+export const popularSongConverter: FirestoreDataConverter<PopularSong> = {
+  toFirestore: (s) => ({
+    title: s.title,
+    artist: s.artist,
+    sortTitle: (s.sortTitle ?? s.title).toLowerCase(),
+  }),
+  fromFirestore: (snap) => ({ id: snap.id, ...snap.data() } as PopularSong),
+};

--- a/tools/seed.js
+++ b/tools/seed.js
@@ -260,6 +260,161 @@ async function seedSessions(uids) {
   }
 }
 
+// ── Popular music lookup data (global, read-only) ──
+
+const POPULAR_ARTISTS = [
+  'The Beatles', 'Jimi Hendrix', 'Led Zeppelin', 'Pink Floyd',
+  'Eric Clapton', 'Stevie Ray Vaughan', 'B.B. King', 'John Mayer',
+  'Eagles', 'Metallica', 'Fleetwood Mac', 'The Rolling Stones',
+  'Nirvana', 'AC/DC', 'Guns N\' Roses', 'Queen', 'David Bowie',
+  'Johnny Cash', 'Bob Dylan', 'Neil Young', 'Joni Mitchell',
+  'Radiohead', 'Coldplay', 'Ed Sheeran', 'Taylor Swift',
+  'John Lennon', 'Paul McCartney', 'George Harrison', 'Jeff Beck',
+  'Carlos Santana', 'Chuck Berry', 'Muddy Waters', 'Robert Johnson',
+  'Django Reinhardt', 'Wes Montgomery', 'Joe Pass', 'Pat Metheny',
+  'Tommy Emmanuel', 'Chet Atkins', 'Mark Knopfler', 'Dire Straits',
+  'The Who', 'Cream', 'Black Sabbath', 'Deep Purple',
+  'Van Halen', 'Joe Satriani', 'Steve Vai', 'Yngwie Malmsteen',
+  'James Taylor', 'Simon & Garfunkel',
+]
+
+const POPULAR_ALBUMS = [
+  { title: 'Abbey Road', artist: 'The Beatles' },
+  { title: 'Led Zeppelin IV', artist: 'Led Zeppelin' },
+  { title: 'Rumours', artist: 'Fleetwood Mac' },
+  { title: 'The Dark Side of the Moon', artist: 'Pink Floyd' },
+  { title: 'Hotel California', artist: 'Eagles' },
+  { title: 'Back in Black', artist: 'AC/DC' },
+  { title: 'Appetite for Destruction', artist: 'Guns N\' Roses' },
+  { title: 'Nevermind', artist: 'Nirvana' },
+  { title: 'OK Computer', artist: 'Radiohead' },
+  { title: 'The Wall', artist: 'Pink Floyd' },
+  { title: 'Wish You Were Here', artist: 'Pink Floyd' },
+  { title: 'Electric Ladyland', artist: 'Jimi Hendrix' },
+  { title: 'Are You Experienced', artist: 'Jimi Hendrix' },
+  { title: 'Unplugged', artist: 'Eric Clapton' },
+  { title: 'Master of Puppets', artist: 'Metallica' },
+  { title: 'A Night at the Opera', artist: 'Queen' },
+  { title: 'Sgt. Pepper\'s Lonely Hearts Club Band', artist: 'The Beatles' },
+  { title: 'Revolver', artist: 'The Beatles' },
+  { title: 'Sticky Fingers', artist: 'The Rolling Stones' },
+  { title: 'Exile on Main St.', artist: 'The Rolling Stones' },
+  { title: 'Brothers in Arms', artist: 'Dire Straits' },
+  { title: 'Paranoid', artist: 'Black Sabbath' },
+  { title: 'Highway to Hell', artist: 'AC/DC' },
+  { title: 'In Utero', artist: 'Nirvana' },
+  { title: 'Continuum', artist: 'John Mayer' },
+  { title: 'Texas Flood', artist: 'Stevie Ray Vaughan' },
+  { title: 'Slowhand', artist: 'Eric Clapton' },
+  { title: 'Harvest', artist: 'Neil Young' },
+  { title: 'Blood on the Tracks', artist: 'Bob Dylan' },
+  { title: 'Blue', artist: 'Joni Mitchell' },
+  { title: 'Supernatural', artist: 'Carlos Santana' },
+  { title: 'The Rise and Fall of Ziggy Stardust', artist: 'David Bowie' },
+  { title: 'Who\'s Next', artist: 'The Who' },
+  { title: 'Live at the Regal', artist: 'B.B. King' },
+  { title: 'Surfing with the Alien', artist: 'Joe Satriani' },
+  { title: 'Sweet Baby James', artist: 'James Taylor' },
+  { title: 'Van Halen', artist: 'Van Halen' },
+  { title: 'The Bends', artist: 'Radiohead' },
+  { title: 'In Rainbows', artist: 'Radiohead' },
+  { title: 'A Rush of Blood to the Head', artist: 'Coldplay' },
+  { title: 'Disraeli Gears', artist: 'Cream' },
+  { title: 'Machine Head', artist: 'Deep Purple' },
+  { title: 'At Folsom Prison', artist: 'Johnny Cash' },
+  { title: 'Blonde on Blonde', artist: 'Bob Dylan' },
+  { title: 'Layla and Other Assorted Love Songs', artist: 'Derek and the Dominos' },
+  { title: '1984', artist: 'Van Halen' },
+  { title: 'Passion and Warfare', artist: 'Steve Vai' },
+  { title: 'Ah Via Musicom', artist: 'Eric Johnson' },
+  { title: 'Bridge over Troubled Water', artist: 'Simon & Garfunkel' },
+  { title: 'Graceland', artist: 'Paul Simon' },
+]
+
+const POPULAR_SONGS_LIST = [
+  { title: 'Stairway to Heaven', artist: 'Led Zeppelin' },
+  { title: 'Hotel California', artist: 'Eagles' },
+  { title: 'Blackbird', artist: 'The Beatles' },
+  { title: 'Yesterday', artist: 'The Beatles' },
+  { title: 'Bohemian Rhapsody', artist: 'Queen' },
+  { title: 'Comfortably Numb', artist: 'Pink Floyd' },
+  { title: 'Wish You Were Here', artist: 'Pink Floyd' },
+  { title: 'Purple Haze', artist: 'Jimi Hendrix' },
+  { title: 'All Along the Watchtower', artist: 'Jimi Hendrix' },
+  { title: 'Layla', artist: 'Eric Clapton' },
+  { title: 'Tears in Heaven', artist: 'Eric Clapton' },
+  { title: 'Wonderful Tonight', artist: 'Eric Clapton' },
+  { title: 'Free Bird', artist: 'Lynyrd Skynyrd' },
+  { title: 'Sweet Child O\' Mine', artist: 'Guns N\' Roses' },
+  { title: 'Nothing Else Matters', artist: 'Metallica' },
+  { title: 'Smells Like Teen Spirit', artist: 'Nirvana' },
+  { title: 'Eruption', artist: 'Van Halen' },
+  { title: 'Sultans of Swing', artist: 'Dire Straits' },
+  { title: 'While My Guitar Gently Weeps', artist: 'The Beatles' },
+  { title: 'Let It Be', artist: 'The Beatles' },
+  { title: 'Hey Joe', artist: 'Jimi Hendrix' },
+  { title: 'Little Wing', artist: 'Jimi Hendrix' },
+  { title: 'Whole Lotta Love', artist: 'Led Zeppelin' },
+  { title: 'Black Dog', artist: 'Led Zeppelin' },
+  { title: 'Thunderstruck', artist: 'AC/DC' },
+  { title: 'Back in Black', artist: 'AC/DC' },
+  { title: 'Smoke on the Water', artist: 'Deep Purple' },
+  { title: 'Iron Man', artist: 'Black Sabbath' },
+  { title: 'Pride and Joy', artist: 'Stevie Ray Vaughan' },
+  { title: 'The Thrill Is Gone', artist: 'B.B. King' },
+  { title: 'Creep', artist: 'Radiohead' },
+  { title: 'Paranoid Android', artist: 'Radiohead' },
+  { title: 'Wonderwall', artist: 'Oasis' },
+  { title: 'Hallelujah', artist: 'Leonard Cohen' },
+  { title: 'Dust in the Wind', artist: 'Kansas' },
+  { title: 'Classical Gas', artist: 'Mason Williams' },
+  { title: 'Gravity', artist: 'John Mayer' },
+  { title: 'Slow Dancing in a Burning Room', artist: 'John Mayer' },
+  { title: 'Blowin\' in the Wind', artist: 'Bob Dylan' },
+  { title: 'Heart of Gold', artist: 'Neil Young' },
+  { title: 'Fire and Rain', artist: 'James Taylor' },
+  { title: 'The Sound of Silence', artist: 'Simon & Garfunkel' },
+  { title: 'Europa', artist: 'Carlos Santana' },
+  { title: 'Samba Pa Ti', artist: 'Carlos Santana' },
+  { title: 'Cliffs of Dover', artist: 'Eric Johnson' },
+  { title: 'Crazy Train', artist: 'Ozzy Osbourne' },
+  { title: 'Fast Car', artist: 'Tracy Chapman' },
+  { title: 'Landslide', artist: 'Fleetwood Mac' },
+  { title: 'More Than Words', artist: 'Extreme' },
+  { title: 'Under the Bridge', artist: 'Red Hot Chili Peppers' },
+]
+
+async function seedPopularMusic() {
+  // Artists
+  const artistBatch = db.batch()
+  for (const name of POPULAR_ARTISTS) {
+    const id = slugify(name)
+    const ref = db.doc(`popularArtists/${id}`)
+    artistBatch.set(ref, { name, sortName: name.toLowerCase() }, { merge: true })
+  }
+  await artistBatch.commit()
+
+  // Albums
+  const albumBatch = db.batch()
+  for (const { title, artist } of POPULAR_ALBUMS) {
+    const id = slugify(`${title}-${artist}`)
+    const ref = db.doc(`popularAlbums/${id}`)
+    albumBatch.set(ref, { title, artist, sortTitle: title.toLowerCase() }, { merge: true })
+  }
+  await albumBatch.commit()
+
+  // Songs
+  const songBatch = db.batch()
+  for (const { title, artist } of POPULAR_SONGS_LIST) {
+    const id = slugify(`${title}-${artist}`)
+    const ref = db.doc(`popularSongs/${id}`)
+    songBatch.set(ref, { title, artist, sortTitle: title.toLowerCase() }, { merge: true })
+  }
+  await songBatch.commit()
+
+  console.log(`[seed] Popular music: ${POPULAR_ARTISTS.length} artists, ${POPULAR_ALBUMS.length} albums, ${POPULAR_SONGS_LIST.length} songs`)
+}
+
 async function verify() {
   const usersSnap = await db.collection('users').get()
   let songsCount = 0
@@ -270,8 +425,14 @@ async function verify() {
     const ss = await db.collection(`users/${u.id}/sessions`).get()
     sessionsCount += ss.size
   }
+  const popArtists = await db.collection('popularArtists').get()
+  const popAlbums = await db.collection('popularAlbums').get()
+  const popSongs = await db.collection('popularSongs').get()
   console.log(
     `[seed] Users: ${usersSnap.size}, Songs: ${songsCount}, Sessions: ${sessionsCount}`,
+  )
+  console.log(
+    `[seed] Popular music: ${popArtists.size} artists, ${popAlbums.size} albums, ${popSongs.size} songs`,
   )
 }
 
@@ -315,6 +476,7 @@ async function main() {
 
   await seedSongs([g1, g2, e1, e2])
   await seedSessions([g1, g2, e1, e2])
+  await seedPopularMusic()
 
   await db.doc('healthcheck/ping').set({ at: Timestamp.now() }, { merge: true })
 


### PR DESCRIPTION
## Summary

- **MusicBrainz API service** — new `MusicbrainzService` for searching and looking up artists, recordings, releases, and genres via the MusicBrainz public API
- **Autocomplete on new-song form** — Title, Artist, and Album fields now offer typeahead suggestions using PrimeNG `AutoComplete`, with a two-tier strategy: fast local Firestore lookup first, then MusicBrainz API fallback when local results are insufficient
- **Popular music Firestore collections** — three new global read-only collections (`popularArtists`, `popularAlbums`, `popularSongs`) with ~50 curated guitar-centric entries each (classic rock, blues, jazz, folk), queried via case-insensitive prefix range
- **Seed script** — `tools/seed.js` updated to populate the popular music collections with batch writes
- **Firestore rules** — read-only access for authenticated users on the new collections
- **Full test coverage** — 26 test suites, 238 tests passing; new specs for MusicBrainz service, popular music converters, PopularMusicService, AutocompleteSuggestionService, and updated new-song component tests

### New files
| File | Purpose |
|------|---------|
| `src/app/models/musicbrainz.ts` | MusicBrainz API response type interfaces |
| `src/app/services/musicbrainz.service.ts` | MusicBrainz API client (search + lookup) |
| `src/app/models/popular-music.ts` | PopularArtist, PopularAlbum, PopularSong interfaces |
| `src/app/storage/popular-music.converters.ts` | Firestore data converters for popular music collections |
| `src/app/services/popular-music.service.ts` | Firestore prefix-range query service |
| `src/app/services/autocomplete-suggestion.service.ts` | Orchestrator: local-first + MusicBrainz fallback, dedup |

### Modified files
| File | Change |
|------|--------|
| `src/app/features/songs/new-song/new-song.component.ts` | Inject suggestion service, add search handlers |
| `src/app/features/songs/new-song/new-song.component.html` | Replace text inputs with `<p-autoComplete>` for Title, Artist, Album |
| `firestore.rules` / `src/app/storage/firestore.rules` | Add read-only rules for popular music collections |
| `tools/seed.js` | Add ~50 entries each for popular artists, albums, songs |

## Test plan
- [x] All 238 tests pass across 26 suites (`npx jest --no-coverage`)
- [ ] Verify autocomplete suggestions appear when typing in Title, Artist, and Album fields
- [ ] Confirm local Firestore results load quickly for seeded data (e.g., typing "Led" suggests "Led Zeppelin")
- [ ] Confirm MusicBrainz fallback triggers when local results are sparse (e.g., an obscure artist name)
- [ ] Confirm users can still type freely and submit without selecting a suggestion
- [ ] Run `node tools/seed.js` against a Firestore instance and verify collections are populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)