### PR TITLE
feat: resource library + design system baseline

### DIFF
--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -12,6 +12,25 @@ import { provideStorage, getStorage } from '@angular/fire/storage';
 import { environment } from "../environments/environment";
 import { providePrimeNG } from 'primeng/config';
 import Aura from '@primeuix/themes/aura';
+import { definePreset } from '@primeuix/themes';
+
+const GuitarJourneyPreset = definePreset(Aura, {
+  semantic: {
+    primary: {
+      50:  '#FDF4EF',
+      100: '#FAE4D5',
+      200: '#F5C9AB',
+      300: '#EEA980',
+      400: '#E58757',
+      500: '#C4622D',
+      600: '#A34E22',
+      700: '#7D3A18',
+      800: '#5A290F',
+      900: '#3A1A09',
+      950: '#1E0D04',
+    }
+  }
+});
 
 export const appConfig: ApplicationConfig = {
   providers: [
@@ -25,7 +44,7 @@ export const appConfig: ApplicationConfig = {
     provideHttpClient(),
     providePrimeNG({
       theme: {
-          preset: Aura,
+          preset: GuitarJourneyPreset,
           options: {
             darkModeSelector: false || 'none'
         }

--- a/src/app/auth/login.component.html
+++ b/src/app/auth/login.component.html
@@ -2,28 +2,28 @@
 
 <form (ngSubmit)="signInWithEmail()" class="space-y-3 max-w-sm">
   <input [(ngModel)]="email" name="email" placeholder="Email"
-         class="w-full rounded border px-3 py-2" />
+         class="w-full rounded-md border border-[var(--gj-border)] bg-[var(--gj-surface)] px-3 py-2" />
 
   <input [(ngModel)]="password" name="password" type="password" placeholder="Password"
-         class="w-full rounded border px-3 py-2" />
+         class="w-full rounded-md border border-[var(--gj-border)] bg-[var(--gj-surface)] px-3 py-2" />
 
   <button type="submit"
-          class="w-full rounded-xl px-4 py-2 bg-indigo-600 text-white font-medium hover:bg-indigo-500">
+          class="w-full rounded-md px-4 py-2 bg-[var(--gj-accent)] text-white font-medium hover:bg-[var(--gj-accent-hover)]">
     Sign in
   </button>
 </form>
 
 <!-- Divider -->
 <div class="flex items-center my-6 max-w-sm">
-  <div class="flex-grow border-t border-neutral-300"></div>
-  <span class="mx-3 text-neutral-500 text-sm">or</span>
-  <div class="flex-grow border-t border-neutral-300"></div>
+  <div class="flex-grow border-t border-[var(--gj-border)]"></div>
+  <span class="mx-3 text-[var(--gj-muted)] text-sm">or</span>
+  <div class="flex-grow border-t border-[var(--gj-border)]"></div>
 </div>
 
 <!-- Google Sign-in -->
 <button type="button"
         (click)="signInWithGoogle()"
-        class="w-full max-w-sm flex items-center justify-center rounded-xl border px-4 py-2 font-medium text-neutral-700 hover:bg-neutral-50">
+        class="w-full max-w-sm flex items-center justify-center rounded-md border border-[var(--gj-border)] px-4 py-2 font-medium text-[var(--gj-text)] hover:bg-[var(--gj-background)]">
   <i class="pi pi-google mr-2"></i>
   Sign in with Google
 </button>

--- a/src/app/auth/register.component.html
+++ b/src/app/auth/register.component.html
@@ -1,4 +1,4 @@
-<section class="max-w-lg mx-auto p-6 bg-white rounded-2xl shadow">
+<section class="max-w-lg mx-auto p-6 bg-[var(--gj-surface)] rounded-lg shadow">
     <h1 class="text-2xl font-semibold mb-4">Create your account</h1>
 
     <form [formGroup]="form" (ngSubmit)="submit()" class="grid gap-4" novalidate>
@@ -81,7 +81,7 @@
 
       <p class="text-sm text-neutral-700 text-center">
         Already have an account?
-        <a routerLink="/login" class="text-indigo-600 hover:underline">Sign in</a>
+        <a routerLink="/login" class="text-[var(--gj-accent)] hover:underline">Sign in</a>
       </p>
     </form>
   </section>

--- a/src/app/core/not-found/not-found.component.html
+++ b/src/app/core/not-found/not-found.component.html
@@ -1,5 +1,5 @@
-<div class="flex flex-col items-center justify-center min-h-screen bg-neutral-50 text-center p-6">
-    <h1 class="text-4xl font-bold text-indigo-700 mb-6">Ouch! Wrong note!</h1>
+<div class="flex flex-col items-center justify-center min-h-screen bg-[var(--gj-background)] text-center p-6">
+    <h1 class="text-4xl font-bold text-[var(--gj-accent)] mb-6">Ouch! Wrong note!</h1>
   
     <img
       src="assets/images/simonon.jpg"
@@ -9,8 +9,8 @@
   
     <button
       (click)="goHome()"
-      class="px-6 py-3 bg-indigo-600 text-white rounded-lg font-medium hover:bg-indigo-500
-             focus:outline-none focus:ring-2 focus:ring-indigo-500"
+      class="px-6 py-3 bg-[var(--gj-accent)] text-white rounded-md font-medium hover:bg-[var(--gj-accent-hover)]
+             focus:outline-none focus:ring-2 focus:ring-[var(--gj-accent)]"
     >
       Return Home
     </button>

--- a/src/app/features/dashboard/dashboard.component.html
+++ b/src/app/features/dashboard/dashboard.component.html
@@ -1,6 +1,6 @@
 <div class="space-y-8">
   <!-- Hero Section with Rotating Carousel -->
-  <section class="relative overflow-hidden rounded-2xl border bg-white">
+  <section class="relative overflow-hidden rounded-lg border bg-[var(--gj-surface)]">
     <!-- Carousel Image with Attribution Overlay -->
     <div 
       class="relative h-[22rem] md:h-[28-rem] w-full bg-cover bg-center"
@@ -89,7 +89,7 @@
   <!-- Stats Cards Section -->
   <section class="grid gap-6 md:grid-cols-3">
     <!-- Last Session Card -->
-    <div class="rounded-2xl border p-5 bg-white">
+    <div class="rounded-lg border p-5 bg-[var(--gj-surface)]">
       <h3 class="font-semibold mb-2">Last session</h3>
       @if (data().lastSession) {
         <p class="text-sm text-neutral-600">
@@ -98,7 +98,7 @@
         </p>
         <a 
           [routerLink]="['/app/sessions', data().lastSession!.id]" 
-          class="inline-block mt-3 text-indigo-600 hover:underline"
+          class="inline-block mt-3 text-[var(--gj-accent)] hover:underline"
         >
           View details
         </a>
@@ -108,7 +108,7 @@
     </div>
 
     <!-- Totals Card -->
-    <div class="rounded-2xl border p-5 bg-white">
+    <div class="rounded-lg border p-5 bg-[var(--gj-surface)]">
       <h3 class="font-semibold mb-2">Totals</h3>
       <ul class="text-sm text-neutral-700 space-y-1">
         <li>Total minutes: <strong>{{ data().totals.minutes }}</strong></li>
@@ -118,7 +118,7 @@
     </div>
 
     <!-- This Week Card -->
-    <div class="rounded-2xl border p-5 bg-white">
+    <div class="rounded-lg border p-5 bg-[var(--gj-surface)]">
       <h3 class="font-semibold mb-2">This week</h3>
       <p class="text-sm text-neutral-600">
         {{ weekTotal() }} minutes so far.

--- a/src/app/features/session/session-resource-picker/session-resource-picker.component.html
+++ b/src/app/features/session/session-resource-picker/session-resource-picker.component.html
@@ -1,1 +1,110 @@
-<p>session-resource-picker works!</p>
+<div class="space-y-4">
+
+  <!-- ── YOUR LIBRARY ─────────────────────────────────────── -->
+  <div>
+    <p class="text-xs font-medium text-neutral-500 uppercase tracking-wide mb-2">Your Library</p>
+
+    @if (libraryLoading()) {
+      <div class="space-y-2">
+        @for (_ of [1, 2, 3]; track $index) {
+          <p-skeleton height="40px" />
+        }
+      </div>
+    } @else if (allResources().length === 0) {
+      <p-message severity="info">No saved resources yet — add a YouTube tutorial, tab, or PDF below and it'll be waiting here next time.</p-message>
+    } @else {
+      <!-- Filters -->
+      <div class="space-y-2 mb-2">
+        <input
+          type="text"
+          pInputText
+          placeholder="Search by name…"
+          [(ngModel)]="labelFilter"
+          class="w-full"
+        />
+        <p-autocomplete
+          [(ngModel)]="tagFilter"
+          [multiple]="true"
+          [dropdown]="false"
+          [suggestions]="[]"
+          placeholder="Filter by tag…"
+          class="w-full"
+        />
+      </div>
+
+      @if (filteredResources.length === 0) {
+        <p-message severity="warn">No resources match your filters.</p-message>
+      } @else {
+        <p-listbox
+          [options]="filteredResources"
+          optionLabel="label"
+          [style]="{ 'width': '100%' }"
+          (onChange)="onLibrarySelect($event.value)"
+        />
+      }
+    }
+  </div>
+
+  <hr class="border-t border-neutral-200">
+
+  <!-- ── ADD NEW ───────────────────────────────────────────── -->
+  <div>
+    <p class="text-xs font-medium text-neutral-500 uppercase tracking-wide mb-2">Add New</p>
+    <div class="space-y-3">
+
+      <p-select
+        [(ngModel)]="newType"
+        [options]="typeOptions"
+        optionLabel="label"
+        optionValue="value"
+        class="w-full"
+        (onChange)="onTypeChange()"
+      />
+
+      <input
+        type="text"
+        pInputText
+        placeholder="URL"
+        [(ngModel)]="newUrl"
+        class="w-full"
+        (blur)="onUrlBlur()"
+      />
+
+      @if (oEmbedLoading()) {
+        <p-skeleton height="112px" />
+      } @else if (oEmbedThumbnail()) {
+        <img
+          [src]="oEmbedThumbnail()"
+          alt="Video thumbnail"
+          class="w-full object-cover rounded-xl"
+        />
+      }
+
+      <input
+        type="text"
+        pInputText
+        placeholder="Label"
+        [(ngModel)]="newLabel"
+        class="w-full"
+      />
+
+      <p-autocomplete
+        [ngModel]="newTags"
+        (ngModelChange)="newTags = $event"
+        [multiple]="true"
+        [dropdown]="false"
+        [suggestions]="tagSuggestions"
+        placeholder="Tags (press Enter to add)"
+        class="w-full"
+      />
+
+      <p-button
+        label="Add"
+        type="button"
+        [disabled]="!canAdd"
+        (click)="onAdd()"
+      />
+    </div>
+  </div>
+
+</div>

--- a/src/app/features/session/session-resource-picker/session-resource-picker.component.spec.ts
+++ b/src/app/features/session/session-resource-picker/session-resource-picker.component.spec.ts
@@ -1,16 +1,40 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { of } from 'rxjs';
 import { SessionResourcePickerComponent } from './session-resource-picker.component';
+import { ResourceService } from '../../../services/resource.service';
+import { Resource } from '../../../models/resource';
+
+const mockResource = (over: Partial<Resource> = {}): Resource => ({
+  id: 'res-1',
+  type: 'youtube',
+  url: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+  label: 'Test Video',
+  tags: ['tag1'],
+  useCount: 0,
+  createdAt: { seconds: 0, nanoseconds: 0 } as any,
+  ...over,
+});
+
+const mockResourceService = {
+  getResources: jest.fn().mockReturnValue(of([])),
+};
 
 describe('SessionResourcePickerComponent', () => {
   let component: SessionResourcePickerComponent;
   let fixture: ComponentFixture<SessionResourcePickerComponent>;
 
   beforeEach(async () => {
+    jest.clearAllMocks();
+    mockResourceService.getResources.mockReturnValue(of([]));
+
     await TestBed.configureTestingModule({
-      declarations: [ SessionResourcePickerComponent ]
-    })
-    .compileComponents();
+      imports: [SessionResourcePickerComponent],
+      providers: [
+        provideNoopAnimations(),
+        { provide: ResourceService, useValue: mockResourceService },
+      ],
+    }).compileComponents();
 
     fixture = TestBed.createComponent(SessionResourcePickerComponent);
     component = fixture.componentInstance;
@@ -19,5 +43,122 @@ describe('SessionResourcePickerComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('sets libraryLoading to false after getResources emits', () => {
+    expect(component.libraryLoading()).toBe(false);
+  });
+
+  it('canAdd is false when url is empty', () => {
+    component.newUrl = '';
+    component.newLabel = 'Some label';
+    expect(component.canAdd).toBe(false);
+  });
+
+  it('canAdd is false when label is empty', () => {
+    component.newUrl = 'https://www.youtube.com/watch?v=dQw4w9WgXcQ';
+    component.newLabel = '';
+    expect(component.canAdd).toBe(false);
+  });
+
+  it('canAdd is false when youtube type but URL is not a valid youtube URL', () => {
+    component.newType = 'youtube';
+    component.newUrl = 'https://example.com/video';
+    component.newLabel = 'My Video';
+    expect(component.canAdd).toBe(false);
+  });
+
+  it('canAdd is true for a valid youtube URL with a label', () => {
+    component.newType = 'youtube';
+    component.newUrl = 'https://www.youtube.com/watch?v=dQw4w9WgXcQ';
+    component.newLabel = 'My Video';
+    expect(component.canAdd).toBe(true);
+  });
+
+  it('canAdd is true for a non-youtube type with any valid https URL', () => {
+    component.newType = 'pdf';
+    component.newUrl = 'https://example.com/tab.pdf';
+    component.newLabel = 'Tab PDF';
+    expect(component.canAdd).toBe(true);
+  });
+
+  it('emits resourceAdded with correct shape when onAdd is called', () => {
+    component.newType = 'pdf';
+    component.newUrl = 'https://example.com/tab.pdf';
+    component.newLabel = 'My Tab';
+    component.newTags = ['Blues', 'Beginner'];
+
+    const emitted: any[] = [];
+    component.resourceAdded.subscribe(v => emitted.push(v));
+
+    component.onAdd();
+
+    expect(emitted).toHaveLength(1);
+    expect(emitted[0]).toEqual({
+      type: 'pdf',
+      url: 'https://example.com/tab.pdf',
+      label: 'My Tab',
+      tags: ['blues', 'beginner'],
+    });
+  });
+
+  it('resets form fields after onAdd', () => {
+    component.newType = 'pdf';
+    component.newUrl = 'https://example.com/tab.pdf';
+    component.newLabel = 'My Tab';
+    component.newTags = ['blues'];
+
+    component.resourceAdded.subscribe(() => {});
+    component.onAdd();
+
+    expect(component.newType).toBe('youtube');
+    expect(component.newUrl).toBe('');
+    expect(component.newLabel).toBe('');
+    expect(component.newTags).toEqual([]);
+  });
+
+  it('emits resourceAdded with resourceId when onLibrarySelect is called', () => {
+    const resource = mockResource({ id: 'lib-id-1', type: 'youtube', tags: ['jazz'] });
+    const emitted: any[] = [];
+    component.resourceAdded.subscribe(v => emitted.push(v));
+
+    component.onLibrarySelect(resource);
+
+    expect(emitted).toHaveLength(1);
+    expect(emitted[0].resourceId).toBe('lib-id-1');
+    expect(emitted[0].url).toBe(resource.url);
+    expect(emitted[0].type).toBe('youtube');
+  });
+
+  it('does not emit if onLibrarySelect receives a resource without an id', () => {
+    const resource = mockResource({ id: undefined });
+    const emitted: any[] = [];
+    component.resourceAdded.subscribe(v => emitted.push(v));
+
+    component.onLibrarySelect(resource);
+
+    expect(emitted).toHaveLength(0);
+  });
+
+  it('filteredResources filters by label case-insensitively', () => {
+    mockResourceService.getResources.mockReturnValue(
+      of([
+        mockResource({ id: '1', label: 'Blues Scale' }),
+        mockResource({ id: '2', label: 'Jazz Chord' }),
+      ])
+    );
+
+    fixture = TestBed.createComponent(SessionResourcePickerComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+
+    component.labelFilter = 'blues';
+    expect(component.filteredResources.map(r => r.id)).toEqual(['1']);
+  });
+
+  it('onTypeChange clears the oEmbed thumbnail', () => {
+    (component as any)._oEmbedThumbnail.set('https://img.youtube.com/vi/test/0.jpg');
+    component.onTypeChange();
+    expect(component.oEmbedThumbnail()).toBeNull();
   });
 });

--- a/src/app/features/session/session-resource-picker/session-resource-picker.component.ts
+++ b/src/app/features/session/session-resource-picker/session-resource-picker.component.ts
@@ -1,16 +1,146 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, DestroyRef, EventEmitter, Output, inject, signal, computed } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormsModule } from '@angular/forms';
+import { AutoComplete } from 'primeng/autocomplete';
+import { ButtonModule } from 'primeng/button';
+import { InputTextModule } from 'primeng/inputtext';
+import { Listbox } from 'primeng/listbox';
+import { Message } from 'primeng/message';
+import { Select } from 'primeng/select';
+import { Skeleton } from 'primeng/skeleton';
+import { ResourceService } from '../../../services/resource.service';
+import { Resource } from '../../../models/resource';
+import { SessionResource } from '../../../models/session-resource';
+import { extractYouTubeEmbedUrl, fetchYouTubeOEmbed } from '../../../utils/youtube';
+
+type ResourceType = 'youtube' | 'pdf' | 'chord-sheet' | 'custom';
 
 @Component({
-    selector: 'app-session-resource-picker',
-    templateUrl: './session-resource-picker.component.html',
-    styleUrls: ['./session-resource-picker.component.scss'],
-    standalone: false
+  selector: 'app-session-resource-picker',
+  standalone: true,
+  imports: [FormsModule, AutoComplete, ButtonModule, InputTextModule, Listbox, Message, Select, Skeleton],
+  templateUrl: './session-resource-picker.component.html',
 })
-export class SessionResourcePickerComponent implements OnInit {
+export class SessionResourcePickerComponent {
+  private resourceService = inject(ResourceService);
+  private destroyRef = inject(DestroyRef);
 
-  constructor() { }
+  @Output() resourceAdded = new EventEmitter<Omit<SessionResource, 'id' | 'pinnedAt'>>();
 
-  ngOnInit(): void {
+  // Library state
+  private _allResources = signal<Resource[]>([]);
+  private _libraryLoading = signal(true);
+
+  readonly libraryLoading = this._libraryLoading.asReadonly();
+  readonly allResources = this._allResources.asReadonly();
+
+  // Filter state (plain properties — template ngModel binds directly)
+  labelFilter = '';
+  tagFilter: string[] = [];
+
+  get filteredResources(): Resource[] {
+    const label = this.labelFilter.toLowerCase();
+    const tags = this.tagFilter;
+    return this._allResources()
+      .filter(r => (label ? r.label.toLowerCase().includes(label) : true))
+      .filter(r => (tags.length ? tags.every(t => r.tags?.includes(t)) : true))
+      .slice(0, 50);
   }
 
+  // Add-new form state
+  newType: ResourceType = 'youtube';
+  newUrl = '';
+  newLabel = '';
+  newTags: string[] = [];
+  tagSuggestions: string[] = [];
+
+  // oEmbed state
+  private _oEmbedLoading = signal(false);
+  private _oEmbedThumbnail = signal<string | null>(null);
+
+  readonly oEmbedLoading = this._oEmbedLoading.asReadonly();
+  readonly oEmbedThumbnail = this._oEmbedThumbnail.asReadonly();
+
+  readonly typeOptions = [
+    { label: 'YouTube', value: 'youtube' },
+    { label: 'PDF', value: 'pdf' },
+    { label: 'Chord Sheet', value: 'chord-sheet' },
+    { label: 'Custom Link', value: 'custom' },
+  ];
+
+  get canAdd(): boolean {
+    if (!this.newLabel.trim()) return false;
+    try {
+      const parsed = new URL(this.newUrl);
+      if (!['http:', 'https:'].includes(parsed.protocol)) return false;
+      if (this.newType === 'youtube' && extractYouTubeEmbedUrl(this.newUrl) === null) return false;
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  constructor() {
+    this.resourceService
+      .getResources()
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: resources => {
+          this._allResources.set(resources);
+          this._libraryLoading.set(false);
+        },
+        error: () => this._libraryLoading.set(false),
+      });
+  }
+
+  async onUrlBlur(): Promise<void> {
+    const url = this.newUrl;
+    if (this.newType !== 'youtube' || !url) return;
+
+    const urlAtFetchStart = url;
+    this._oEmbedLoading.set(true);
+    this._oEmbedThumbnail.set(null);
+
+    const oembed = await fetchYouTubeOEmbed(url);
+
+    if (this.newUrl !== urlAtFetchStart) return; // stale response guard
+
+    this._oEmbedLoading.set(false);
+    if (oembed) {
+      if (!this.newLabel.trim()) this.newLabel = oembed.title;
+      this._oEmbedThumbnail.set(oembed.thumbnailUrl || null);
+    }
+  }
+
+  onTypeChange(): void {
+    this._oEmbedThumbnail.set(null);
+  }
+
+  onAdd(): void {
+    if (!this.canAdd) return;
+
+    this.resourceAdded.emit({
+      type: this.newType,
+      url: this.newUrl,
+      label: this.newLabel.trim(),
+      tags: this.newTags.map(t => t.toLowerCase()),
+    });
+
+    this.newType = 'youtube';
+    this.newUrl = '';
+    this.newLabel = '';
+    this.newTags = [];
+    this._oEmbedThumbnail.set(null);
+  }
+
+  onLibrarySelect(resource: Resource): void {
+    if (!resource?.id) return;
+    this.resourceAdded.emit({
+      resourceId: resource.id,
+      type: resource.type,
+      url: resource.url,
+      label: resource.label,
+      tags: resource.tags ?? [],
+    });
+  }
 }

--- a/src/app/features/session/session-resource/session-resource.component.html
+++ b/src/app/features/session/session-resource/session-resource.component.html
@@ -1,1 +1,39 @@
-<p>The resource component will be a place where resources can be made available during a practice session</p>
+@if (resource.type === 'youtube') {
+  <div class="rounded-lg overflow-hidden">
+    <iframe
+      [src]="safeEmbedUrl"
+      width="100%"
+      height="200"
+      frameborder="0"
+      allowfullscreen
+    ></iframe>
+  </div>
+} @else {
+  <a
+    [href]="resource.url"
+    target="_blank"
+    rel="noopener noreferrer"
+    class="flex items-center gap-2 text-sm text-neutral-700 hover:text-neutral-900"
+  >
+    @if (resource.type === 'pdf') {
+      <i class="pi pi-file-pdf flex-shrink-0"></i>
+    } @else if (resource.type === 'chord-sheet') {
+      <i class="pi pi-list flex-shrink-0"></i>
+    } @else {
+      <i class="pi pi-link flex-shrink-0"></i>
+    }
+    <span class="truncate">{{ resource.label }}</span>
+  </a>
+}
+
+@if (showRemove) {
+  <p-button
+    type="button"
+    severity="danger"
+    variant="text"
+    icon="pi pi-times"
+    styleClass="!w-11 !h-11 flex items-center justify-center"
+    [attr.aria-label]="'Remove ' + resource.label"
+    (click)="remove.emit()"
+  />
+}

--- a/src/app/features/session/session-resource/session-resource.component.spec.ts
+++ b/src/app/features/session/session-resource/session-resource.component.spec.ts
@@ -1,23 +1,72 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-
+import { By } from '@angular/platform-browser';
 import { SessionResourceComponent } from './session-resource.component';
+import { SessionResource } from '../../../models/session-resource';
 
-describe('SessionResourceComponentComponent', () => {
-  let component: SessionResourceComponent;
-  let fixture: ComponentFixture<SessionResourceComponent>;
+const makeResource = (over: Partial<SessionResource> = {}): SessionResource => ({
+  type: 'youtube',
+  url: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+  label: 'Test Video',
+  tags: [],
+  pinnedAt: { seconds: 0, nanoseconds: 0 } as any,
+  ...over,
+});
 
-  beforeEach(async () => {
+describe('SessionResourceComponent', () => {
+  async function setup(resource: SessionResource, showRemove = false) {
     await TestBed.configureTestingModule({
-      declarations: [ SessionResourceComponent ]
-    })
-    .compileComponents();
+      imports: [SessionResourceComponent],
+    }).compileComponents();
 
-    fixture = TestBed.createComponent(SessionResourceComponent);
-    component = fixture.componentInstance;
+    const fixture = TestBed.createComponent(SessionResourceComponent);
+    fixture.componentInstance.resource = resource;
+    fixture.componentInstance.showRemove = showRemove;
     fixture.detectChanges();
+    return fixture;
+  }
+
+  it('renders an iframe for youtube type', async () => {
+    const fixture = await setup(makeResource({ type: 'youtube' }));
+    expect(fixture.debugElement.query(By.css('iframe'))).toBeTruthy();
   });
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
+  it('renders an anchor with the resource URL for pdf type', async () => {
+    const fixture = await setup(makeResource({ type: 'pdf', url: 'https://example.com/tab.pdf' }));
+    const anchor = fixture.debugElement.query(By.css('a'));
+    expect(anchor).toBeTruthy();
+    expect(anchor.nativeElement.getAttribute('href')).toBe('https://example.com/tab.pdf');
+  });
+
+  it('uses pi-file-pdf icon for pdf type', async () => {
+    const fixture = await setup(makeResource({ type: 'pdf', url: 'https://example.com/tab.pdf' }));
+    expect(fixture.debugElement.query(By.css('i.pi-file-pdf'))).toBeTruthy();
+  });
+
+  it('uses pi-list icon for chord-sheet type', async () => {
+    const fixture = await setup(makeResource({ type: 'chord-sheet', url: 'https://example.com/chords' }));
+    expect(fixture.debugElement.query(By.css('i.pi-list'))).toBeTruthy();
+  });
+
+  it('uses pi-link icon for custom type', async () => {
+    const fixture = await setup(makeResource({ type: 'custom', url: 'https://example.com' }));
+    expect(fixture.debugElement.query(By.css('i.pi-link'))).toBeTruthy();
+  });
+
+  it('shows remove button when showRemove=true', async () => {
+    const fixture = await setup(makeResource(), true);
+    expect(fixture.debugElement.query(By.css('p-button'))).toBeTruthy();
+  });
+
+  it('hides remove button by default (showRemove=false)', async () => {
+    const fixture = await setup(makeResource(), false);
+    expect(fixture.debugElement.query(By.css('p-button'))).toBeNull();
+  });
+
+  it('emits the remove event when remove is triggered', async () => {
+    const fixture = await setup(makeResource(), true);
+    const removeSpy = jest.fn();
+    fixture.componentInstance.remove.subscribe(removeSpy);
+    fixture.componentInstance.remove.emit();
+    expect(removeSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/app/features/session/session-resource/session-resource.component.ts
+++ b/src/app/features/session/session-resource/session-resource.component.ts
@@ -1,16 +1,26 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, EventEmitter, Input, Output, inject } from '@angular/core';
+import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
+import { ButtonModule } from 'primeng/button';
+import { SessionResource } from '../../../models/session-resource';
+import { extractYouTubeEmbedUrl } from '../../../utils/youtube';
 
 @Component({
-    selector: 'app-session-resource',
-    templateUrl: './session-resource.component.html',
-    styleUrls: ['./session-resource.component.scss'],
-    standalone: false
+  selector: 'app-session-resource',
+  standalone: true,
+  imports: [ButtonModule],
+  templateUrl: './session-resource.component.html',
 })
-export class SessionResourceComponent implements OnInit {
+export class SessionResourceComponent {
+  private sanitizer = inject(DomSanitizer);
 
-  constructor() { }
+  @Input({ required: true }) resource!: SessionResource;
+  @Input() showRemove = false;
+  @Output() remove = new EventEmitter<void>();
 
-  ngOnInit(): void {
+  get safeEmbedUrl(): SafeResourceUrl {
+    // Only call inside @if (resource.type === 'youtube') — the ! is safe there
+    return this.sanitizer.bypassSecurityTrustResourceUrl(
+      extractYouTubeEmbedUrl(this.resource.url)!
+    );
   }
-
 }

--- a/src/app/features/session/session.component.html
+++ b/src/app/features/session/session.component.html
@@ -84,10 +84,27 @@
               </div>
             }
 
-            <div id="sessionModeChoice" class="mt-4">
-              <p class="text-sm text-neutral-700 mb-2">Do you want to add practice resources?</p>
-              <p-button id="addResources" type="button" (click)="addResourcesToSession()">Yes</p-button>
-            </div>
+          </div>
+
+          <!-- Practice Resources -->
+          <div class="border-t border-[var(--gj-border)] pt-4">
+            <p class="text-xs font-medium text-[var(--gj-muted)] uppercase tracking-[0.05em] mb-3">
+              Practice Resources
+            </p>
+
+            @if (pendingResources().length > 0) {
+              <div class="space-y-2 mb-4">
+                @for (resource of pendingResources(); track resource.url) {
+                  <app-session-resource
+                    [resource]="$any(resource)"
+                    [showRemove]="true"
+                    (remove)="onResourceRemoved(resource.url)"
+                  />
+                }
+              </div>
+            }
+
+            <app-session-resource-picker (resourceAdded)="onResourceAdded($event)" />
           </div>
 
           <div class="flex items-center gap-3">
@@ -124,9 +141,16 @@
           </button>
         </div>
 
-        @if (resourcesAdded()) {
-          <div id="resourcesSection" class="pt-4 border-t border-neutral-200">
-            <!--  <app-session-resource></app-session-resource> -->
+        @if (pendingResources().length > 0) {
+          <div id="resourcesSection" class="pt-4 border-t border-[var(--gj-border)]">
+            <p class="text-xs font-medium text-[var(--gj-muted)] uppercase tracking-[0.05em] mb-3">
+              Your Resources
+            </p>
+            <div class="space-y-3">
+              @for (resource of pendingResources(); track resource.url) {
+                <app-session-resource [resource]="$any(resource)" [showRemove]="false" />
+              }
+            </div>
           </div>
         }
       </div>

--- a/src/app/features/session/session.component.html
+++ b/src/app/features/session/session.component.html
@@ -4,7 +4,7 @@
 
   @switch (status()) {
     @case ('Before') {
-      <div class="bg-white shadow rounded-2xl p-6">
+      <div class="bg-[var(--gj-surface)] shadow rounded-lg p-6">
         <form
           [formGroup]="beforeForm"
           id="sessionForm"
@@ -28,8 +28,8 @@
               min="0"
               aria-describedby="practiceTimeHelp practiceTimeError"
               [attr.aria-invalid]="practiceTimeCtrl.invalid && (practiceTimeCtrl.touched || practiceTimeCtrl.dirty)"
-              class="w-full rounded-xl border border-neutral-300 bg-white text-neutral-900 placeholder:text-neutral-400 px-3 py-2
-                         focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
+              class="w-full rounded-md border border-[var(--gj-border)] bg-[var(--gj-surface)] text-[var(--gj-text)] placeholder:text-neutral-400 px-3 py-2
+                         focus:outline-none focus:ring-2 focus:ring-[var(--gj-accent)] focus:border-[var(--gj-accent)]"
             />
             <small id="practiceTimeHelp" class="text-sm text-neutral-500">Numbers only, in minutes.</small>
 
@@ -52,8 +52,8 @@
               pInputTextarea
               rows="4"
               [attr.aria-invalid]="whatToPracticeCtrl.invalid && (whatToPracticeCtrl.touched || whatToPracticeCtrl.dirty)"
-              class="w-full rounded-xl border border-neutral-300 bg-white text-neutral-900 placeholder:text-neutral-400 px-3 py-2
-                         focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
+              class="w-full rounded-md border border-[var(--gj-border)] bg-[var(--gj-surface)] text-[var(--gj-text)] placeholder:text-neutral-400 px-3 py-2
+                         focus:outline-none focus:ring-2 focus:ring-[var(--gj-accent)] focus:border-[var(--gj-accent)]"
             ></textarea>
 
             @if (whatToPracticeCtrl.invalid && (whatToPracticeCtrl.touched || whatToPracticeCtrl.dirty)) {
@@ -75,8 +75,8 @@
               placeholder="Directed practice requires intent. Set yours…"
               pInputText
               [attr.aria-invalid]="sessionIntentCtrl.invalid && (sessionIntentCtrl.touched || sessionIntentCtrl.dirty)"
-              class="w-full rounded-xl border border-neutral-300 bg-white text-neutral-900 placeholder:text-neutral-400 px-3 py-2
-                         focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
+              class="w-full rounded-md border border-[var(--gj-border)] bg-[var(--gj-surface)] text-[var(--gj-text)] placeholder:text-neutral-400 px-3 py-2
+                         focus:outline-none focus:ring-2 focus:ring-[var(--gj-accent)] focus:border-[var(--gj-accent)]"
             />
             @if (sessionIntentCtrl.invalid && (sessionIntentCtrl.touched || sessionIntentCtrl.dirty)) {
               <div class="text-sm text-red-600 mt-1" aria-live="polite">
@@ -111,8 +111,8 @@
             <button
               id="startButton"
               type="submit"
-              class="inline-flex items-center justify-center rounded-xl bg-indigo-600 px-4 py-2 text-white font-medium
-                         hover:bg-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 disabled:opacity-50"
+              class="inline-flex items-center justify-center rounded-md bg-[var(--gj-accent)] px-4 py-2 text-white font-medium
+                         hover:bg-[var(--gj-accent-hover)] focus:outline-none focus:ring-2 focus:ring-[var(--gj-accent)] disabled:opacity-50"
               [disabled]="prePracticeForm.invalid"
             >
               Start
@@ -123,7 +123,7 @@
     }
 
     @case ('During') {
-      <div class="bg-white shadow rounded-2xl p-6 space-y-6">
+      <div class="bg-[var(--gj-surface)] shadow rounded-lg p-6 space-y-6">
         <div id="timerSection">
           <p class="font-semibold text-3xl tracking-tight text-neutral-900">{{ timeDisplay() }}</p>
           <h2 class="text-lg text-neutral-700 mt-1">Keep going! Make it a good session!</h2>
@@ -133,7 +133,7 @@
           <button
             id="endButton"
             type="button"
-            class="mt-4 inline-flex items-center justify-center rounded-xl bg-rose-600 px-4 py-2 text-white font-medium
+            class="mt-4 inline-flex items-center justify-center rounded-md bg-rose-600 px-4 py-2 text-white font-medium
                        hover:bg-rose-500 focus:outline-none focus:ring-2 focus:ring-rose-500"
             (click)="stopTimer()"
           >
@@ -157,7 +157,7 @@
     }
 
     @case ('After') {
-      <div class="bg-white shadow rounded-2xl p-6">
+      <div class="bg-[var(--gj-surface)] shadow rounded-lg p-6">
         <div class="mb-6 flex flex-col items-center">
           <h2 class="text-xl font-semibold text-neutral-900 mb-2">You did it!</h2>
           <img
@@ -165,7 +165,7 @@
             [height]="400"
             src="assets/images/cherry-592.png"
             alt="Man playing guitar"
-            class="rounded-xl shadow"
+            class="rounded-md shadow"
           />
         </div>
 
@@ -188,8 +188,8 @@
               pInputTextarea
               rows="6"
               [attr.aria-invalid]="sessionReflectionCtrl.invalid && (sessionReflectionCtrl.touched || sessionReflectionCtrl.dirty)"
-              class="w-full rounded-xl border border-neutral-300 bg-white text-neutral-900 placeholder:text-neutral-400 px-3 py-2
-                         focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
+              class="w-full rounded-md border border-[var(--gj-border)] bg-[var(--gj-surface)] text-[var(--gj-text)] placeholder:text-neutral-400 px-3 py-2
+                         focus:outline-none focus:ring-2 focus:ring-[var(--gj-accent)] focus:border-[var(--gj-accent)]"
             ></textarea>
 
             @if (sessionReflectionCtrl.invalid && (sessionReflectionCtrl.touched || sessionReflectionCtrl.dirty)) {
@@ -211,8 +211,8 @@
               pInputTextarea
               rows="4"
               [attr.aria-invalid]="goalForNextTimeCtrl.invalid && (goalForNextTimeCtrl.touched || goalForNextTimeCtrl.dirty)"
-              class="w-full rounded-xl border border-neutral-300 bg-white text-neutral-900 placeholder:text-neutral-400 px-3 py-2
-                         focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
+              class="w-full rounded-md border border-[var(--gj-border)] bg-[var(--gj-surface)] text-[var(--gj-text)] placeholder:text-neutral-400 px-3 py-2
+                         focus:outline-none focus:ring-2 focus:ring-[var(--gj-accent)] focus:border-[var(--gj-accent)]"
             ></textarea>
 
             @if (goalForNextTimeCtrl.invalid && (goalForNextTimeCtrl.touched || goalForNextTimeCtrl.dirty)) {
@@ -227,8 +227,8 @@
               type="button"
               (click)="onSubmit()"
               [disabled]="loading()"
-              class="inline-flex items-center justify-center rounded-xl bg-indigo-600 px-4 py-2 text-white font-medium
-                         hover:bg-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 disabled:opacity-50"
+              class="inline-flex items-center justify-center rounded-md bg-[var(--gj-accent)] px-4 py-2 text-white font-medium
+                         hover:bg-[var(--gj-accent-hover)] focus:outline-none focus:ring-2 focus:ring-[var(--gj-accent)] disabled:opacity-50"
             >
               @if (!saving()) { <span>Finish</span> }
               @if (saving()) {

--- a/src/app/features/session/session.component.spec.ts
+++ b/src/app/features/session/session.component.spec.ts
@@ -1,6 +1,7 @@
 // session.component.spec.ts
 import { TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { SessionComponent } from './session.component';
 import { of, Subject } from 'rxjs';
 import { convertToParamMap } from '@angular/router';
@@ -55,6 +56,7 @@ describe('SessionComponent (template-driven behaviors)', () => {
       imports: [SessionComponent],
       // Ignore unknown PrimeNG elements/directives used in the template (pInputText, pInputTextarea, p-button)
       providers: [
+        provideNoopAnimations(),
         { provide: SessionService, useValue: sessionSvcMock },
         { provide: ResourceService, useValue: resourceSvcMock },
       ],
@@ -118,14 +120,18 @@ describe('SessionComponent (template-driven behaviors)', () => {
       expect(cmp.status()).toBe('During');
     });
 
-    /* TODO: Enable this test once the addResourcesToSession() method is implemented
-    it('clicking "Yes" to add resources calls addResourcesToSession()', () => {
-      const { fixture, cmp } = createFixtureWithStatus('Before');
-      const addBtn = fixture.debugElement.query(By.css('#addResources'))?.nativeElement as HTMLButtonElement;
-      addBtn.click();
-      fixture.detectChanges();
+    it('renders app-session-resource-picker in the Before phase', () => {
+      const { fixture } = createFixtureWithStatus('Before');
+      expect(fixture.debugElement.query(By.css('app-session-resource-picker'))).toBeTruthy();
     });
-    */
+
+    it('shows app-session-resource with remove button for each pending resource', () => {
+      const { fixture, cmp } = createFixtureWithStatus('Before');
+      cmp.onResourceAdded({ type: 'pdf', url: 'https://example.com/tab.pdf', label: 'Tab' });
+      fixture.detectChanges();
+      const resourceEls = fixture.debugElement.queryAll(By.css('app-session-resource'));
+      expect(resourceEls.length).toBe(1);
+    });
   });
 
   describe('DURING state', () => {
@@ -142,17 +148,18 @@ describe('SessionComponent (template-driven behaviors)', () => {
 
       expect(cmp.status()).toBe('After');});
 
-    /* TODO: Enable this test once the resourcesAdded() signal and addResourcesToSession() method are implemented
-    it('renders the resources section when resourcesAdded() is true', () => {
-      const { fixture, cmp } = createFixtureWithStatus('During');
-      // Flip the signal and re-render
-      //cmp.resourcesAdded = jest.fn(() => true);
+    it('shows #resourcesSection in During phase when there are pending resources', () => {
+      const { fixture, cmp } = createFixtureWithStatus('Before');
+      cmp.onResourceAdded({ type: 'youtube', url: 'https://www.youtube.com/watch?v=abc', label: 'Lesson' });
+      cmp.start();
       fixture.detectChanges();
-
-      const resources = fixture.debugElement.query(By.css('#resourcesSection'))?.nativeElement as HTMLElement;
-      expect(resources).toBeTruthy();
+      expect(fixture.debugElement.query(By.css('#resourcesSection'))).toBeTruthy();
     });
-    */
+
+    it('hides #resourcesSection in During phase when no pending resources', () => {
+      const { fixture } = createFixtureWithStatus('During');
+      expect(fixture.debugElement.query(By.css('#resourcesSection'))).toBeNull();
+    });
   });
 
   describe('AFTER state', () => {

--- a/src/app/features/session/session.component.spec.ts
+++ b/src/app/features/session/session.component.spec.ts
@@ -7,6 +7,7 @@ import { convertToParamMap } from '@angular/router';
 import { Session } from '@models/session';
 import { SessionService } from '@services/session.service'
 import { fakeAsync, flushMicrotasks, tick } from '@angular/core/testing';
+import { ResourceService } from '../../services/resource.service';
 
 
 function type(el: HTMLInputElement | HTMLTextAreaElement, value: string) {
@@ -38,6 +39,11 @@ const makeSession = (over: Partial<Session> = {}): Session => ({
     create:          jest.fn((session: Partial<Session>) => Promise.resolve('new-id')),
   };
 
+  const resourceSvcMock: any = {
+    getResources:     jest.fn(() => of([])),
+    saveResources:    jest.fn(() => Promise.resolve(undefined)),
+  };
+
   async function setup() {
     paramMap$ = new Subject();
     get$ = new Subject<Session>();
@@ -50,6 +56,7 @@ describe('SessionComponent (template-driven behaviors)', () => {
       // Ignore unknown PrimeNG elements/directives used in the template (pInputText, pInputTextarea, p-button)
       providers: [
         { provide: SessionService, useValue: sessionSvcMock },
+        { provide: ResourceService, useValue: resourceSvcMock },
       ],
     }).compileComponents();
   });
@@ -210,84 +217,104 @@ describe('SessionComponent (template-driven behaviors)', () => {
       jest.spyOn(cmp as any, 'elapsedSeconds').mockReturnValue(1200); // 20 minutes
     }
   
-    it('resolves: turns off saving/loading after 800ms and navigates to /app', fakeAsync(() => {
+    it('resolves: turns off saving/loading and navigates to /app', async () => {
       const fixture = TestBed.createComponent(SessionComponent);
       const cmp = fixture.componentInstance;
-  
-      // Stub router directly on the component to avoid TestBed changes
+
       const navigate = jest.fn();
       (cmp as any).router = { navigate };
-  
-      // Mock create() -> resolved promise
-      // If your spec already has sessionSvcMock, reuse it; otherwise adapt as needed.
+
       const svc = TestBed.inject(SessionService) as any;
-      createSpy = jest.spyOn(svc, 'create').mockResolvedValue(undefined);
-  
+      createSpy = jest.spyOn(svc, 'create').mockResolvedValue('new-id');
+
       primeValidForm(cmp);
-  
-      // Call
-      cmp.onSubmit();
-  
+
+      const submitPromise = cmp.onSubmit();
+
       // Immediately after calling, flags should be true
       expect(cmp.saving()).toBe(true);
       expect(cmp.loading()).toBe(true);
-  
-      // Let the promise resolve
-      flushMicrotasks();
-  
-      // The success branch sets a setTimeout(800) before flipping flags + navigate
-      tick(800);
+
+      await submitPromise;
       fixture.detectChanges();
-  
+
       expect(createSpy).toHaveBeenCalledWith({
         whatToPractice: 'Chord changes: C ↔︎ F',
         sessionIntent: 'Improve clean transitions',
         postPracticeReflection: 'Barre chords improving',
         goalForNextTime: 'Metronome @ 70 BPM, 10 mins',
-        practiceTime: 1200 / 60, // 20
+        practiceTime: 1200 / 60,
       });
       expect(cmp.saving()).toBe(false);
       expect(cmp.loading()).toBe(false);
       expect(navigate).toHaveBeenCalledWith(['/app']);
-    }));
-  
-    it('rejects: logs error and turns off saving/loading; does not navigate', fakeAsync(() => {
+    });
+
+    it('rejects: logs error and turns off saving/loading; does not navigate', async () => {
       const fixture = TestBed.createComponent(SessionComponent);
       const cmp = fixture.componentInstance;
-  
-      // Stub router again
+
       const navigate = jest.fn();
       (cmp as any).router = { navigate };
-  
-      // Mock create() -> rejected promise
+
       const svc = TestBed.inject(SessionService) as any;
       const err = new Error('create failed');
       createSpy = jest.spyOn(svc, 'create').mockRejectedValue(err);
-  
-      // Spy on console.error to assert it’s called (optional but nice)
+
       const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
-  
+
       primeValidForm(cmp);
-  
-      // Call
-      cmp.onSubmit();
-  
-      // Immediately after calling, flags should be true
+
+      const submitPromise = cmp.onSubmit();
+
       expect(cmp.saving()).toBe(true);
       expect(cmp.loading()).toBe(true);
-  
-      // Let the promise reject
-      flushMicrotasks();
+
+      await submitPromise;
       fixture.detectChanges();
-  
-      // No 800ms delay on the error path — flags flip immediately
+
       expect(errorSpy).toHaveBeenCalledWith('Error saving session:', err);
       expect(cmp.saving()).toBe(false);
       expect(cmp.loading()).toBe(false);
       expect(navigate).not.toHaveBeenCalled();
-  
+
       errorSpy.mockRestore();
-    }));
+    });
   });
-  
+
+  describe('pendingResources management', () => {
+    it('onResourceAdded appends a resource to pendingResources', () => {
+      const { cmp } = createFixtureWithStatus('Before');
+      const resource = { type: 'youtube' as const, url: 'https://www.youtube.com/watch?v=abc', label: 'Test' };
+      cmp.onResourceAdded(resource);
+      expect(cmp.pendingResources()).toHaveLength(1);
+      expect(cmp.pendingResources()[0].url).toBe(resource.url);
+    });
+
+    it('onResourceAdded deduplicates by URL', () => {
+      const { cmp } = createFixtureWithStatus('Before');
+      const resource = { type: 'youtube' as const, url: 'https://www.youtube.com/watch?v=abc', label: 'Test' };
+      cmp.onResourceAdded(resource);
+      cmp.onResourceAdded({ ...resource, label: 'Duplicate' });
+      expect(cmp.pendingResources()).toHaveLength(1);
+    });
+
+    it('onResourceRemoved removes a resource by URL', () => {
+      const { cmp } = createFixtureWithStatus('Before');
+      const r1 = { type: 'youtube' as const, url: 'https://www.youtube.com/watch?v=aaa', label: 'A' };
+      const r2 = { type: 'pdf' as const, url: 'https://example.com/tab.pdf', label: 'B' };
+      cmp.onResourceAdded(r1);
+      cmp.onResourceAdded(r2);
+      cmp.onResourceRemoved(r1.url);
+      expect(cmp.pendingResources()).toHaveLength(1);
+      expect(cmp.pendingResources()[0].url).toBe(r2.url);
+    });
+
+    it('onResourceRemoved is a no-op when URL is not present', () => {
+      const { cmp } = createFixtureWithStatus('Before');
+      expect(() => cmp.onResourceRemoved('https://not-in-list.com')).not.toThrow();
+      expect(cmp.pendingResources()).toHaveLength(0);
+    });
+  });
+
 });

--- a/src/app/features/session/session.component.ts
+++ b/src/app/features/session/session.component.ts
@@ -4,6 +4,8 @@ import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angula
 import { ButtonModule } from 'primeng/button';
 import { SessionService } from '@services/session.service';
 import { Router } from '@angular/router';
+import { ResourceService } from '../../services/resource.service';
+import { SessionResource } from '../../models/session-resource';
 export type SessionPhase = 'Before' | 'During' | 'After';
 
 @Component({
@@ -15,6 +17,7 @@ export type SessionPhase = 'Before' | 'During' | 'After';
 export class SessionComponent {
   private fb = inject(FormBuilder);
   private sessionService = inject(SessionService);
+  private resourceService = inject(ResourceService);
   private router = inject(Router);
   private destroyRef = inject(DestroyRef);
 
@@ -26,6 +29,10 @@ export class SessionComponent {
   // Track whether user opted to add resources (your HTML checks resourcesAdded())
   private _resourcesAdded = signal(false);
   resourcesAdded = this._resourcesAdded.asReadonly();
+
+  // Pending resources staged before session save
+  private _pendingResources = signal<Omit<SessionResource, 'id' | 'pinnedAt'>[]>([]);
+  readonly pendingResources = this._pendingResources.asReadonly();
 
   // Loading/saving flags for the AFTER form buttons
   private _loading = signal(false);
@@ -96,6 +103,15 @@ export class SessionComponent {
     this._resourcesAdded.set(true);
   }
 
+  onResourceAdded(resource: Omit<SessionResource, 'id' | 'pinnedAt'>): void {
+    if (this._pendingResources().some(r => r.url === resource.url)) return;
+    this._pendingResources.update(arr => [...arr, resource]);
+  }
+
+  onResourceRemoved(url: string): void {
+    this._pendingResources.update(arr => arr.filter(r => r.url !== url));
+  }
+
   // Called by BEFORE form submit
   start() {
 
@@ -121,28 +137,28 @@ export class SessionComponent {
   }
 
   // Called by AFTER form button(s)
-  onSubmit() {
-
+  async onSubmit(): Promise<void> {
     this._loading.set(true);
     this._saving.set(true);
-
-    this.sessionService.create({
-      whatToPractice: this.whatToPracticeCtrl.value,
-      sessionIntent: this.sessionIntentCtrl.value,
-      postPracticeReflection: this.sessionReflectionCtrl.value,
-      goalForNextTime: this.goalForNextTimeCtrl.value,
-      practiceTime: this.elapsedSeconds() / 60,
-    }).then(() => {
-    setTimeout(() => {
+    try {
+      const sessionId = await this.sessionService.create({
+        whatToPractice: this.whatToPracticeCtrl.value,
+        sessionIntent: this.sessionIntentCtrl.value,
+        postPracticeReflection: this.sessionReflectionCtrl.value,
+        goalForNextTime: this.goalForNextTimeCtrl.value,
+        practiceTime: this.elapsedSeconds() / 60,
+      });
+      if (this._pendingResources().length > 0) {
+        await this.resourceService.saveResources(sessionId, this._pendingResources());
+      }
       this._saving.set(false);
       this._loading.set(false);
       this.router.navigate(['/app']);
-    }, 800);
-  }).catch((error) => {
-    console.error('Error saving session:', error);
-    this._saving.set(false);
-    this._loading.set(false);
-  });
+    } catch (error) {
+      console.error('Error saving session:', error);
+      this._saving.set(false);
+      this._loading.set(false);
+    }
   }
 
   // ---------- UTIL ----------

--- a/src/app/features/session/session.component.ts
+++ b/src/app/features/session/session.component.ts
@@ -6,12 +6,14 @@ import { SessionService } from '@services/session.service';
 import { Router } from '@angular/router';
 import { ResourceService } from '../../services/resource.service';
 import { SessionResource } from '../../models/session-resource';
+import { SessionResourcePickerComponent } from './session-resource-picker/session-resource-picker.component';
+import { SessionResourceComponent } from './session-resource/session-resource.component';
 export type SessionPhase = 'Before' | 'During' | 'After';
 
 @Component({
   selector: 'app-session',
   standalone: true,
-  imports: [CommonModule, ReactiveFormsModule, ButtonModule],
+  imports: [CommonModule, ReactiveFormsModule, ButtonModule, SessionResourcePickerComponent, SessionResourceComponent],
   templateUrl: './session.component.html',
 })
 export class SessionComponent {
@@ -25,10 +27,6 @@ export class SessionComponent {
   // Session phase for the @switch in the template
   private _status = signal<SessionPhase>('Before');
   status = this._status.asReadonly();
-
-  // Track whether user opted to add resources (your HTML checks resourcesAdded())
-  private _resourcesAdded = signal(false);
-  resourcesAdded = this._resourcesAdded.asReadonly();
 
   // Pending resources staged before session save
   private _pendingResources = signal<Omit<SessionResource, 'id' | 'pinnedAt'>[]>([]);
@@ -99,10 +97,6 @@ export class SessionComponent {
   get prePracticeForm() { return this.beforeForm; }
 
   // ---------- TEMPLATE CALLED HELPERS ----------
-  addResourcesToSession() {
-    this._resourcesAdded.set(true);
-  }
-
   onResourceAdded(resource: Omit<SessionResource, 'id' | 'pinnedAt'>): void {
     if (this._pendingResources().some(r => r.url === resource.url)) return;
     this._pendingResources.update(arr => [...arr, resource]);

--- a/src/app/features/songs/display-song/display-song.component.html
+++ b/src/app/features/songs/display-song/display-song.component.html
@@ -26,7 +26,7 @@
             <dt class="text-sm font-medium text-neutral-500">Audio</dt>
             <dd>
               <a [href]="song()!.audioLink" target="_blank" rel="noopener noreferrer"
-                 class="text-indigo-600 hover:underline">{{ song()!.audioLink }}</a>
+                 class="text-[var(--gj-accent)] hover:underline">{{ song()!.audioLink }}</a>
             </dd>
           }
 
@@ -34,7 +34,7 @@
             <dt class="text-sm font-medium text-neutral-500">Video</dt>
             <dd>
               <a [href]="song()!.videoLink" target="_blank" rel="noopener noreferrer"
-                 class="text-indigo-600 hover:underline">{{ song()!.videoLink }}</a>
+                 class="text-[var(--gj-accent)] hover:underline">{{ song()!.videoLink }}</a>
             </dd>
           }
 
@@ -42,7 +42,7 @@
             <dt class="text-sm font-medium text-neutral-500">Apple Music</dt>
             <dd>
               <a [href]="song()!.appleMusicLink" target="_blank" rel="noopener noreferrer"
-                 class="text-indigo-600 hover:underline">{{ song()!.appleMusicLink }}</a>
+                 class="text-[var(--gj-accent)] hover:underline">{{ song()!.appleMusicLink }}</a>
             </dd>
           }
 
@@ -50,7 +50,7 @@
             <dt class="text-sm font-medium text-neutral-500">Spotify</dt>
             <dd>
               <a [href]="song()!.spotifyLink" target="_blank" rel="noopener noreferrer"
-                 class="text-indigo-600 hover:underline">{{ song()!.spotifyLink }}</a>
+                 class="text-[var(--gj-accent)] hover:underline">{{ song()!.spotifyLink }}</a>
             </dd>
           }
 
@@ -61,7 +61,7 @@
                 @for (link of song()!.notationLinks; track link) {
                   <li>
                     <a [href]="link" target="_blank" rel="noopener noreferrer"
-                       class="text-indigo-600 hover:underline">{{ link }}</a>
+                       class="text-[var(--gj-accent)] hover:underline">{{ link }}</a>
                   </li>
                 }
               </ul>

--- a/src/app/features/songs/new-song/new-song.component.html
+++ b/src/app/features/songs/new-song/new-song.component.html
@@ -1,7 +1,7 @@
 <h1 class="text-2xl font-semibold tracking-tight text-neutral-900 mb-4">Add Song</h1>
 
 <div class="px-4 py-6 md:px-6 lg:px-8">
-  <div class="bg-white shadow rounded-2xl p-6">
+  <div class="bg-[var(--gj-surface)] shadow rounded-lg p-6">
     <form
       [formGroup]="songForm"
       class="grid gap-6"
@@ -19,8 +19,8 @@
           [minQueryLength]="5"
           [forceSelection]="false"
           placeholder="Song or exercise name"
-          inputStyleClass="w-full rounded-xl border border-neutral-300 bg-white text-neutral-900 placeholder:text-neutral-400 px-3 py-2
-                 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
+          inputStyleClass="w-full rounded-md border border-[var(--gj-border)] bg-[var(--gj-surface)] text-[var(--gj-text)] placeholder:text-neutral-400 px-3 py-2
+                 focus:outline-none focus:ring-2 focus:ring-[var(--gj-accent)] focus:border-[var(--gj-accent)]"
           styleClass="w-full"
         />
         @if (titleCtrl.invalid && (titleCtrl.touched || titleCtrl.dirty)) {
@@ -39,8 +39,8 @@
           [minQueryLength]="5"
           [forceSelection]="false"
           placeholder="Artist or composer"
-          inputStyleClass="w-full rounded-xl border border-neutral-300 bg-white text-neutral-900 placeholder:text-neutral-400 px-3 py-2
-                 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
+          inputStyleClass="w-full rounded-md border border-[var(--gj-border)] bg-[var(--gj-surface)] text-[var(--gj-text)] placeholder:text-neutral-400 px-3 py-2
+                 focus:outline-none focus:ring-2 focus:ring-[var(--gj-accent)] focus:border-[var(--gj-accent)]"
           styleClass="w-full"
         />
         @if (artistCtrl.invalid && (artistCtrl.touched || artistCtrl.dirty)) {
@@ -59,8 +59,8 @@
           [minQueryLength]="5"
           [forceSelection]="false"
           placeholder="Album name (optional)"
-          inputStyleClass="w-full rounded-xl border border-neutral-300 bg-white text-neutral-900 placeholder:text-neutral-400 px-3 py-2
-                 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
+          inputStyleClass="w-full rounded-md border border-[var(--gj-border)] bg-[var(--gj-surface)] text-[var(--gj-text)] placeholder:text-neutral-400 px-3 py-2
+                 focus:outline-none focus:ring-2 focus:ring-[var(--gj-accent)] focus:border-[var(--gj-accent)]"
           styleClass="w-full"
         />
       </div>
@@ -74,8 +74,8 @@
           formControlName="genre"
           placeholder="e.g. Rock, Jazz, Classical (optional)"
           pInputText
-          class="w-full rounded-xl border border-neutral-300 bg-white text-neutral-900 placeholder:text-neutral-400 px-3 py-2
-                 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
+          class="w-full rounded-md border border-[var(--gj-border)] bg-[var(--gj-surface)] text-[var(--gj-text)] placeholder:text-neutral-400 px-3 py-2
+                 focus:outline-none focus:ring-2 focus:ring-[var(--gj-accent)] focus:border-[var(--gj-accent)]"
         />
       </div>
 
@@ -88,8 +88,8 @@
           formControlName="audioLink"
           placeholder="https://... (optional)"
           pInputText
-          class="w-full rounded-xl border border-neutral-300 bg-white text-neutral-900 placeholder:text-neutral-400 px-3 py-2
-                 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
+          class="w-full rounded-md border border-[var(--gj-border)] bg-[var(--gj-surface)] text-[var(--gj-text)] placeholder:text-neutral-400 px-3 py-2
+                 focus:outline-none focus:ring-2 focus:ring-[var(--gj-accent)] focus:border-[var(--gj-accent)]"
         />
       </div>
 
@@ -102,8 +102,8 @@
           formControlName="videoLink"
           placeholder="https://... (optional)"
           pInputText
-          class="w-full rounded-xl border border-neutral-300 bg-white text-neutral-900 placeholder:text-neutral-400 px-3 py-2
-                 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
+          class="w-full rounded-md border border-[var(--gj-border)] bg-[var(--gj-surface)] text-[var(--gj-text)] placeholder:text-neutral-400 px-3 py-2
+                 focus:outline-none focus:ring-2 focus:ring-[var(--gj-accent)] focus:border-[var(--gj-accent)]"
         />
       </div>
 
@@ -116,8 +116,8 @@
           formControlName="appleMusicLink"
           placeholder="https://music.apple.com/... (optional)"
           pInputText
-          class="w-full rounded-xl border border-neutral-300 bg-white text-neutral-900 placeholder:text-neutral-400 px-3 py-2
-                 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
+          class="w-full rounded-md border border-[var(--gj-border)] bg-[var(--gj-surface)] text-[var(--gj-text)] placeholder:text-neutral-400 px-3 py-2
+                 focus:outline-none focus:ring-2 focus:ring-[var(--gj-accent)] focus:border-[var(--gj-accent)]"
         />
       </div>
 
@@ -130,8 +130,8 @@
           formControlName="spotifyLink"
           placeholder="https://open.spotify.com/... (optional)"
           pInputText
-          class="w-full rounded-xl border border-neutral-300 bg-white text-neutral-900 placeholder:text-neutral-400 px-3 py-2
-                 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
+          class="w-full rounded-md border border-[var(--gj-border)] bg-[var(--gj-surface)] text-[var(--gj-text)] placeholder:text-neutral-400 px-3 py-2
+                 focus:outline-none focus:ring-2 focus:ring-[var(--gj-accent)] focus:border-[var(--gj-accent)]"
         />
       </div>
 
@@ -146,8 +146,8 @@
                 [formControlName]="$index"
                 placeholder="https://... (optional)"
                 pInputText
-                class="flex-1 rounded-xl border border-neutral-300 bg-white text-neutral-900 placeholder:text-neutral-400 px-3 py-2
-                       focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
+                class="flex-1 rounded-md border border-[var(--gj-border)] bg-[var(--gj-surface)] text-[var(--gj-text)] placeholder:text-neutral-400 px-3 py-2
+                       focus:outline-none focus:ring-2 focus:ring-[var(--gj-accent)] focus:border-[var(--gj-accent)]"
               />
               @if (notationLinksArray.length > 1) {
                 <button
@@ -176,8 +176,8 @@
         <button
           type="submit"
           [disabled]="songForm.invalid || saving()"
-          class="inline-flex items-center justify-center rounded-xl bg-indigo-600 px-4 py-2 text-white font-medium
-                 hover:bg-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 disabled:opacity-50"
+          class="inline-flex items-center justify-center rounded-md bg-[var(--gj-accent)] px-4 py-2 text-white font-medium
+                 hover:bg-[var(--gj-accent-hover)] focus:outline-none focus:ring-2 focus:ring-[var(--gj-accent)] disabled:opacity-50"
         >
           @if (!saving()) { <span>Save Song</span> }
           @if (saving()) {
@@ -190,7 +190,7 @@
         </button>
         <button
           type="button"
-          class="inline-flex items-center justify-center rounded-xl border border-neutral-300 px-4 py-2 text-neutral-700 font-medium
+          class="inline-flex items-center justify-center rounded-md border border-[var(--gj-border)] px-4 py-2 text-neutral-700 font-medium
                  hover:bg-neutral-50 focus:outline-none focus:ring-2 focus:ring-neutral-400"
           (click)="cancel()"
         >

--- a/src/app/features/songs/songs.component.html
+++ b/src/app/features/songs/songs.component.html
@@ -6,8 +6,8 @@
     type="button"
     label="Add Song"
     icon="pi pi-plus"
-    class="inline-flex items-center justify-center rounded-xl bg-indigo-600 px-4 py-2 text-white font-medium
-           hover:bg-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+    class="inline-flex items-center justify-center rounded-xl bg-[var(--gj-accent)] px-4 py-2 text-white font-medium
+           hover:bg-[var(--gj-accent-hover)] focus:outline-none focus:ring-2 focus:ring-[var(--gj-accent)]"
     (click)="addSong()"
   ></button>
 </div>

--- a/src/app/models/resource.ts
+++ b/src/app/models/resource.ts
@@ -1,0 +1,12 @@
+import { Timestamp } from 'firebase/firestore';
+
+export interface Resource {
+  id?: string;
+  type: 'youtube' | 'pdf' | 'chord-sheet' | 'custom';
+  url: string;
+  label: string;
+  tags?: string[];
+  useCount?: number;
+  lastUsedAt?: Timestamp;
+  createdAt: Timestamp;
+}

--- a/src/app/models/session-resource.ts
+++ b/src/app/models/session-resource.ts
@@ -1,0 +1,11 @@
+import { Timestamp } from 'firebase/firestore';
+
+export interface SessionResource {
+  id?: string;
+  resourceId?: string;  // FK to users/{uid}/resources/{id}; undefined until saveResources() resolves
+  type: 'youtube' | 'pdf' | 'chord-sheet' | 'custom';
+  url: string;
+  label: string;
+  tags?: string[];
+  pinnedAt: Timestamp;
+}

--- a/src/app/services/resource.service.spec.ts
+++ b/src/app/services/resource.service.spec.ts
@@ -1,0 +1,179 @@
+jest.mock('@angular/fire/firestore', () => ({
+  Firestore: class {},
+  collectionData: jest.fn(),
+}));
+
+jest.mock('firebase/firestore', () => {
+  const withConverter = jest.fn().mockReturnThis();
+  const collection = jest.fn(() => ({ withConverter, _isMock: true }));
+  const doc = jest.fn((db: any, path: string) => ({ _path: path }));
+
+  return {
+    getFirestore: jest.fn(() => ({})),
+    collection,
+    doc,
+    query: jest.fn((q: any) => q),
+    where: jest.fn(),
+    orderBy: jest.fn(),
+    limit: jest.fn(),
+    addDoc: jest.fn(async () => ({ id: 'new-res-id' })),
+    getDocs: jest.fn(async () => ({ empty: true, docs: [] })),
+    updateDoc: jest.fn(async () => undefined),
+    deleteDoc: jest.fn(async () => undefined),
+    serverTimestamp: jest.fn(() => 'server-ts'),
+    increment: jest.fn((n: number) => ({ _increment: n })),
+  };
+});
+
+import { TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
+import { Auth } from '@angular/fire/auth';
+
+import * as afs from '@angular/fire/firestore';
+import * as fbfs from 'firebase/firestore';
+
+import { ResourceService } from './resource.service';
+
+describe('ResourceService', () => {
+  let service: ResourceService;
+  const mockAuth: Partial<Auth> = { currentUser: { uid: 'u1' } as any };
+
+  beforeEach(() => {
+    (mockAuth as any).currentUser = { uid: 'u1' } as any;
+
+    TestBed.configureTestingModule({
+      providers: [
+        ResourceService,
+        { provide: (afs as any).Firestore, useValue: {} },
+        { provide: Auth, useValue: mockAuth },
+      ],
+    });
+
+    service = TestBed.inject(ResourceService);
+    jest.clearAllMocks();
+    (afs.collectionData as jest.Mock).mockReturnValue(of([]));
+  });
+
+  describe('getResources()', () => {
+    it('queries users/{uid}/resources ordered by createdAt desc, limit 200', () => {
+      service.getResources();
+
+      expect(fbfs.collection).toHaveBeenCalledWith(expect.anything(), 'users/u1/resources');
+      expect(fbfs.orderBy).toHaveBeenCalledWith('createdAt', 'desc');
+      expect(fbfs.limit).toHaveBeenCalledWith(200);
+      expect(afs.collectionData).toHaveBeenCalledWith(expect.anything(), { idField: 'id' });
+    });
+
+    it('returns an Observable', () => {
+      const result = service.getResources();
+      expect(result.subscribe).toBeDefined();
+    });
+  });
+
+  describe('getSessionResources()', () => {
+    it('queries the session resources subcollection ordered by pinnedAt asc', () => {
+      service.getSessionResources('sess1');
+
+      expect(fbfs.collection).toHaveBeenCalledWith(
+        expect.anything(),
+        'users/u1/sessions/sess1/resources'
+      );
+      expect(fbfs.orderBy).toHaveBeenCalledWith('pinnedAt', 'asc');
+    });
+  });
+
+  describe('saveResources()', () => {
+    const newResource = {
+      type: 'youtube' as const,
+      url: 'https://www.youtube.com/watch?v=abc',
+      label: 'Test video',
+      tags: ['blues'],
+    };
+
+    it('creates a global library doc and a session pin for a new resource (no dedup hit)', async () => {
+      (fbfs.getDocs as jest.Mock).mockResolvedValue({ empty: true, docs: [] });
+
+      await service.saveResources('sess1', [newResource]);
+
+      // dedup query ran
+      expect(fbfs.getDocs).toHaveBeenCalledTimes(1);
+      // addDoc called twice: global lib + session pin
+      expect(fbfs.addDoc).toHaveBeenCalledTimes(2);
+    });
+
+    it('reuses existing global doc when URL dedup finds a match', async () => {
+      (fbfs.getDocs as jest.Mock).mockResolvedValue({
+        empty: false,
+        docs: [{ id: 'existing-id' }],
+      });
+
+      await service.saveResources('sess1', [newResource]);
+
+      // no new global lib doc created
+      expect(fbfs.addDoc).toHaveBeenCalledTimes(1); // only session pin
+      // touchResource called via updateDoc
+      expect(fbfs.updateDoc).toHaveBeenCalledTimes(1);
+    });
+
+    it('touches an existing resource (has resourceId) and writes session pin', async () => {
+      const existingResource = { ...newResource, resourceId: 'res42' };
+
+      await service.saveResources('sess1', [existingResource]);
+
+      // no dedup query needed
+      expect(fbfs.getDocs).not.toHaveBeenCalled();
+      // updateDoc from touchResource + addDoc for session pin
+      expect(fbfs.updateDoc).toHaveBeenCalledTimes(1);
+      expect(fbfs.addDoc).toHaveBeenCalledTimes(1);
+    });
+
+    it('sets pinnedAt via serverTimestamp on the session pin', async () => {
+      (fbfs.getDocs as jest.Mock).mockResolvedValue({ empty: true, docs: [] });
+
+      await service.saveResources('sess1', [newResource]);
+
+      const pinCall = (fbfs.addDoc as jest.Mock).mock.calls[1];
+      expect(pinCall[1]).toMatchObject({ pinnedAt: 'server-ts' });
+    });
+  });
+
+  describe('deleteResource()', () => {
+    it('calls deleteDoc on users/{uid}/resources/{id}', async () => {
+      await service.deleteResource('res1');
+
+      expect(fbfs.doc).toHaveBeenCalledWith(expect.anything(), 'users/u1/resources/res1');
+      expect(fbfs.deleteDoc).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('updateResource()', () => {
+    it('calls updateDoc with label and tags changes', async () => {
+      await service.updateResource('res1', { label: 'Updated', tags: ['rock'] });
+
+      expect(fbfs.doc).toHaveBeenCalledWith(expect.anything(), 'users/u1/resources/res1');
+      expect(fbfs.updateDoc).toHaveBeenCalledWith(
+        expect.anything(),
+        { label: 'Updated', tags: ['rock'] }
+      );
+    });
+  });
+
+  describe('touchResource()', () => {
+    it('increments useCount and sets lastUsedAt to serverTimestamp', async () => {
+      await service.touchResource('res1');
+
+      expect(fbfs.doc).toHaveBeenCalledWith(expect.anything(), 'users/u1/resources/res1');
+      expect(fbfs.updateDoc).toHaveBeenCalledWith(expect.anything(), {
+        useCount: { _increment: 1 },
+        lastUsedAt: 'server-ts',
+      });
+    });
+  });
+
+  describe('uid()', () => {
+    it('throws when no user is authenticated', () => {
+      (mockAuth as any).currentUser = null;
+      expect(() => service.getResources()).toThrow('No authenticated user');
+    });
+  });
+});

--- a/src/app/services/resource.service.ts
+++ b/src/app/services/resource.service.ts
@@ -1,0 +1,131 @@
+import { Injectable } from '@angular/core';
+import { Firestore, collectionData } from '@angular/fire/firestore';
+import { Auth } from '@angular/fire/auth';
+import {
+  getFirestore,
+  collection,
+  doc,
+  query,
+  where,
+  orderBy,
+  limit,
+  addDoc,
+  getDocs,
+  updateDoc,
+  deleteDoc,
+  serverTimestamp,
+  increment,
+} from 'firebase/firestore';
+import { Observable } from 'rxjs';
+import { Resource } from '../models/resource';
+import { SessionResource } from '../models/session-resource';
+import { resourceConverter, sessionResourceConverter } from '../storage/converters';
+
+@Injectable({ providedIn: 'root' })
+export class ResourceService {
+  constructor(private fs: Firestore, private auth: Auth) {}
+
+  private uid(): string {
+    const uid = this.auth.currentUser?.uid;
+    if (!uid) throw new Error('No authenticated user');
+    return uid;
+  }
+
+  getResources(): Observable<Resource[]> {
+    const uid = this.uid();
+    const db = getFirestore();
+    const col = collection(db, `users/${uid}/resources`).withConverter(resourceConverter);
+    const q = query(col, orderBy('createdAt', 'desc'), limit(200));
+    return collectionData(q, { idField: 'id' }) as unknown as Observable<Resource[]>;
+  }
+
+  getSessionResources(sessionId: string): Observable<SessionResource[]> {
+    const uid = this.uid();
+    const db = getFirestore();
+    const col = collection(db, `users/${uid}/sessions/${sessionId}/resources`).withConverter(
+      sessionResourceConverter
+    );
+    const q = query(col, orderBy('pinnedAt', 'asc'));
+    return collectionData(q, { idField: 'id' }) as unknown as Observable<SessionResource[]>;
+  }
+
+  async saveResources(
+    sessionId: string,
+    resources: Omit<SessionResource, 'id' | 'pinnedAt'>[]
+  ): Promise<void> {
+    const uid = this.uid();
+    const db = getFirestore();
+
+    for (const resource of resources) {
+      let globalResourceId: string;
+
+      if (!resource.resourceId) {
+        const dupQ = query(
+          collection(db, `users/${uid}/resources`),
+          where('url', '==', resource.url),
+          limit(1)
+        );
+        const existing = await getDocs(dupQ);
+
+        if (!existing.empty) {
+          globalResourceId = existing.docs[0].id;
+          await this.touchResource(globalResourceId);
+        } else {
+          const ref = await addDoc(
+            collection(db, `users/${uid}/resources`).withConverter(resourceConverter),
+            {
+              type: resource.type,
+              url: resource.url,
+              label: resource.label,
+              tags: resource.tags ?? [],
+              createdAt: serverTimestamp(),
+              useCount: 0,
+            } as any
+          );
+          globalResourceId = ref.id;
+        }
+      } else {
+        globalResourceId = resource.resourceId;
+        await this.touchResource(globalResourceId);
+      }
+
+      await addDoc(
+        collection(db, `users/${uid}/sessions/${sessionId}/resources`).withConverter(
+          sessionResourceConverter
+        ),
+        {
+          resourceId: globalResourceId,
+          type: resource.type,
+          url: resource.url,
+          label: resource.label,
+          tags: resource.tags ?? [],
+          pinnedAt: serverTimestamp(),
+        } as any
+      );
+    }
+  }
+
+  async deleteResource(resourceId: string): Promise<void> {
+    const uid = this.uid();
+    const db = getFirestore();
+    await deleteDoc(doc(db, `users/${uid}/resources/${resourceId}`));
+  }
+
+  async updateResource(
+    resourceId: string,
+    changes: Partial<Pick<Resource, 'label' | 'tags'>>
+  ): Promise<void> {
+    const uid = this.uid();
+    const db = getFirestore();
+    await updateDoc(doc(db, `users/${uid}/resources/${resourceId}`), changes);
+  }
+
+  async touchResource(resourceId: string): Promise<void> {
+    const uid = this.uid();
+    const db = getFirestore();
+    await updateDoc(doc(db, `users/${uid}/resources/${resourceId}`), {
+      useCount: increment(1),
+      lastUsedAt: serverTimestamp(),
+    });
+  }
+}

--- a/src/app/shells/app-shell.component.html
+++ b/src/app/shells/app-shell.component.html
@@ -1,5 +1,5 @@
 <!-- Sticky top bar -->
-<header class="sticky top-0 z-50 bg-white/90 backdrop-blur border-b border-neutral-200">
+<header class="sticky top-0 z-50 bg-[var(--gj-surface)]/90 backdrop-blur border-b border-[var(--gj-border)]">
     <div class="mx-auto max-w-6xl px-4">
       <p-menubar [model]="items()">
         <ng-template pTemplate="start">

--- a/src/app/storage/converters.spec.ts
+++ b/src/app/storage/converters.spec.ts
@@ -3,10 +3,14 @@ import {
     sessionConverter,
     songConverter,
     userDocumentConverter,
+    resourceConverter,
+    sessionResourceConverter,
     type Session,
     type Song,
     type UserDocument,
   } from './converters';
+import type { Resource } from '../models/resource';
+import type { SessionResource } from '../models/session-resource';
   
 
   
@@ -208,5 +212,128 @@ import {
         });
       });
     });
+
+    describe('resourceConverter', () => {
+      const ts: any = { seconds: 1000, nanoseconds: 0 };
+
+      it('toFirestore maps optional fields to defaults and never includes id', () => {
+        const r: Resource = {
+          type: 'youtube',
+          url: 'https://www.youtube.com/watch?v=abc',
+          label: 'Intro to barre chords',
+          createdAt: ts,
+        };
+
+        const doc = resourceConverter.toFirestore(r);
+
+        expect(doc).toEqual({
+          type: 'youtube',
+          url: 'https://www.youtube.com/watch?v=abc',
+          label: 'Intro to barre chords',
+          tags: [],
+          useCount: 0,
+          lastUsedAt: null,
+          createdAt: ts,
+        });
+        expect('id' in (doc as any)).toBe(false);
+      });
+
+      it('toFirestore preserves provided tags, useCount, and lastUsedAt', () => {
+        const ts2: any = { seconds: 2000, nanoseconds: 0 };
+        const r: Resource = {
+          type: 'pdf',
+          url: 'https://example.com/tab.pdf',
+          label: 'Tab sheet',
+          tags: ['blues', 'scale'],
+          useCount: 5,
+          lastUsedAt: ts2,
+          createdAt: ts,
+        };
+
+        const doc = resourceConverter.toFirestore(r);
+
+        expect(doc.tags).toEqual(['blues', 'scale']);
+        expect(doc.useCount).toBe(5);
+        expect(doc.lastUsedAt).toBe(ts2);
+      });
+
+      it('fromFirestore returns { id, ...data }', () => {
+        const snap = {
+          id: 'res1',
+          data: () => ({
+            type: 'youtube',
+            url: 'https://www.youtube.com/watch?v=abc',
+            label: 'Barre chords',
+            tags: ['chords'],
+            useCount: 2,
+            lastUsedAt: null,
+            createdAt: ts,
+          }),
+        } as any;
+
+        const result = resourceConverter.fromFirestore(snap);
+        expect(result.id).toBe('res1');
+        expect(result.type).toBe('youtube');
+        expect(result.label).toBe('Barre chords');
+      });
+    });
+
+    describe('sessionResourceConverter', () => {
+      const ts: any = { seconds: 3000, nanoseconds: 0 };
+
+      it('toFirestore maps resourceId to null when omitted and never includes id', () => {
+        const r: SessionResource = {
+          type: 'custom',
+          url: 'https://example.com',
+          label: 'Reference',
+          pinnedAt: ts,
+        };
+
+        const doc = sessionResourceConverter.toFirestore(r);
+
+        expect(doc).toEqual({
+          resourceId: null,
+          type: 'custom',
+          url: 'https://example.com',
+          label: 'Reference',
+          tags: [],
+          pinnedAt: ts,
+        });
+        expect('id' in (doc as any)).toBe(false);
+      });
+
+      it('toFirestore preserves resourceId and tags when provided', () => {
+        const r: SessionResource = {
+          resourceId: 'res42',
+          type: 'pdf',
+          url: 'https://example.com/tab.pdf',
+          label: 'Tab',
+          tags: ['blues'],
+          pinnedAt: ts,
+        };
+
+        const doc = sessionResourceConverter.toFirestore(r);
+
+        expect(doc.resourceId).toBe('res42');
+        expect(doc.tags).toEqual(['blues']);
+      });
+
+      it('fromFirestore returns { id, ...data }', () => {
+        const snap = {
+          id: 'pin1',
+          data: () => ({
+            resourceId: 'res99',
+            type: 'youtube',
+            url: 'https://www.youtube.com/watch?v=xyz',
+            label: 'Justin Guitar',
+            tags: [],
+            pinnedAt: ts,
+          }),
+        } as any;
+
+        const result = sessionResourceConverter.fromFirestore(snap);
+        expect(result.id).toBe('pin1');
+        expect(result.resourceId).toBe('res99');
+      });
+    });
   });
-  

--- a/src/app/storage/converters.ts
+++ b/src/app/storage/converters.ts
@@ -1,6 +1,8 @@
 // Strongly typed Firestore converters based on your models
 
 import { FirestoreDataConverter, Timestamp } from 'firebase/firestore';
+import { Resource } from '../models/resource';
+import { SessionResource } from '../models/session-resource';
 
 export interface Session {
   id?: string;
@@ -77,4 +79,29 @@ export const userDocumentConverter: FirestoreDataConverter<UserDocument> = {
     storagePath: d.storagePath
   }),
   fromFirestore: (snap) => ({ id: snap.id, ...snap.data() } as UserDocument),
+};
+
+export const resourceConverter: FirestoreDataConverter<Resource> = {
+  toFirestore: (r) => ({
+    type: r.type,
+    url: r.url,
+    label: r.label,
+    tags: r.tags ?? [],
+    useCount: r.useCount ?? 0,
+    lastUsedAt: r.lastUsedAt ?? null,
+    createdAt: r.createdAt,
+  }),
+  fromFirestore: (snap) => ({ id: snap.id, ...snap.data() } as Resource),
+};
+
+export const sessionResourceConverter: FirestoreDataConverter<SessionResource> = {
+  toFirestore: (r) => ({
+    resourceId: r.resourceId ?? null,
+    type: r.type,
+    url: r.url,
+    label: r.label,
+    tags: r.tags ?? [],
+    pinnedAt: r.pinnedAt,
+  }),
+  fromFirestore: (snap) => ({ id: snap.id, ...snap.data() } as SessionResource),
 };

--- a/src/app/utils/youtube.spec.ts
+++ b/src/app/utils/youtube.spec.ts
@@ -1,0 +1,80 @@
+import { extractYouTubeEmbedUrl, fetchYouTubeOEmbed } from './youtube';
+
+describe('extractYouTubeEmbedUrl', () => {
+  it('extracts video ID from watch?v= URL', () => {
+    expect(extractYouTubeEmbedUrl('https://www.youtube.com/watch?v=dQw4w9WgXcQ'))
+      .toBe('https://www.youtube.com/embed/dQw4w9WgXcQ');
+  });
+
+  it('extracts video ID from youtu.be short URL', () => {
+    expect(extractYouTubeEmbedUrl('https://youtu.be/dQw4w9WgXcQ'))
+      .toBe('https://www.youtube.com/embed/dQw4w9WgXcQ');
+  });
+
+  it('extracts video ID from /shorts/ URL', () => {
+    expect(extractYouTubeEmbedUrl('https://www.youtube.com/shorts/dQw4w9WgXcQ'))
+      .toBe('https://www.youtube.com/embed/dQw4w9WgXcQ');
+  });
+
+  it('returns embed URL as-is when already in embed format', () => {
+    expect(extractYouTubeEmbedUrl('https://www.youtube.com/embed/dQw4w9WgXcQ'))
+      .toBe('https://www.youtube.com/embed/dQw4w9WgXcQ');
+  });
+
+  it('returns null for a non-YouTube URL', () => {
+    expect(extractYouTubeEmbedUrl('https://vimeo.com/123456')).toBeNull();
+  });
+
+  it('returns null for an invalid URL string', () => {
+    expect(extractYouTubeEmbedUrl('not-a-url')).toBeNull();
+  });
+
+  it('returns null for a YouTube URL with no video ID', () => {
+    expect(extractYouTubeEmbedUrl('https://www.youtube.com/watch')).toBeNull();
+  });
+});
+
+describe('fetchYouTubeOEmbed', () => {
+  const g = globalThis as any;
+  let savedFetch: unknown;
+
+  beforeEach(() => { savedFetch = g.fetch; });
+  afterEach(() => { g.fetch = savedFetch; });
+
+  it('returns title and thumbnailUrl on success', async () => {
+    g.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ title: 'Rick Astley', thumbnail_url: 'https://i.ytimg.com/vi/dQw4w9WgXcQ/hqdefault.jpg' }),
+    });
+    expect(await fetchYouTubeOEmbed('https://www.youtube.com/watch?v=dQw4w9WgXcQ')).toEqual({
+      title: 'Rick Astley',
+      thumbnailUrl: 'https://i.ytimg.com/vi/dQw4w9WgXcQ/hqdefault.jpg',
+    });
+  });
+
+  it('returns null when response is not ok', async () => {
+    g.fetch = jest.fn().mockResolvedValue({ ok: false });
+    expect(await fetchYouTubeOEmbed('https://www.youtube.com/watch?v=private')).toBeNull();
+  });
+
+  it('returns null when fetch throws (network error)', async () => {
+    g.fetch = jest.fn().mockRejectedValue(new TypeError('Failed to fetch'));
+    expect(await fetchYouTubeOEmbed('https://www.youtube.com/watch?v=x')).toBeNull();
+  });
+
+  it('returns null when JSON is malformed', async () => {
+    g.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => { throw new SyntaxError('Unexpected token'); },
+    });
+    expect(await fetchYouTubeOEmbed('https://www.youtube.com/watch?v=x')).toBeNull();
+  });
+
+  it('defaults missing title and thumbnail_url to empty string', async () => {
+    g.fetch = jest.fn().mockResolvedValue({ ok: true, json: async () => ({}) });
+    expect(await fetchYouTubeOEmbed('https://www.youtube.com/watch?v=x')).toEqual({
+      title: '',
+      thumbnailUrl: '',
+    });
+  });
+});

--- a/src/app/utils/youtube.ts
+++ b/src/app/utils/youtube.ts
@@ -1,0 +1,47 @@
+export interface YouTubeOEmbed {
+  title: string;
+  thumbnailUrl: string;
+}
+
+export function extractYouTubeEmbedUrl(url: string): string | null {
+  try {
+    const parsed = new URL(url);
+    const hostname = parsed.hostname.replace('www.', '');
+
+    if (hostname === 'youtube.com') {
+      if (parsed.pathname === '/watch') {
+        const v = parsed.searchParams.get('v');
+        return v ? `https://www.youtube.com/embed/${v}` : null;
+      }
+      if (parsed.pathname.startsWith('/shorts/')) {
+        const videoId = parsed.pathname.split('/')[2];
+        return videoId ? `https://www.youtube.com/embed/${videoId}` : null;
+      }
+      if (parsed.pathname.startsWith('/embed/')) {
+        return url;
+      }
+    }
+
+    if (hostname === 'youtu.be') {
+      const videoId = parsed.pathname.slice(1);
+      return videoId ? `https://www.youtube.com/embed/${videoId}` : null;
+    }
+
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+export async function fetchYouTubeOEmbed(url: string): Promise<YouTubeOEmbed | null> {
+  try {
+    const response = await fetch(
+      `https://www.youtube.com/oembed?url=${encodeURIComponent(url)}&format=json`
+    );
+    if (!response.ok) return null;
+    const data = await response.json();
+    return { title: data.title ?? '', thumbnailUrl: data.thumbnail_url ?? '' };
+  } catch {
+    return null;
+  }
+}

--- a/src/app/welcome/welcome.component.html
+++ b/src/app/welcome/welcome.component.html
@@ -11,7 +11,7 @@
         <li>• Track minutes, streaks, and milestones</li>
         <li>• Organize songs, tabs, and exercises</li>
       </ul>
-      <a routerLink="/register" class="inline-block rounded-xl px-4 py-2 bg-indigo-600 text-white hover:bg-indigo-700">
+      <a routerLink="/register" class="inline-block rounded-md px-4 py-2 bg-[var(--gj-accent)] text-white hover:bg-[var(--gj-accent-hover)]">
         Get started
       </a>
     </div>

--- a/src/index.html
+++ b/src/index.html
@@ -2,14 +2,16 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>GuitarPracticeJournal</title>
+  <title>Guitar Journey</title>
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
-  <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500&amp;display=swap" rel="stylesheet">
-  <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+  <!-- Cabinet Grotesk — display/hero font -->
+  <link href="https://api.fontshare.com/v2/css?f[]=cabinet-grotesk@700,800&display=swap" rel="stylesheet">
+  <!-- DM Sans — body/UI font -->
+  <link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500&display=swap" rel="stylesheet">
   <link rel="manifest" href="manifest.webmanifest">
-  <meta name="theme-color" content="#1976d2">
+  <meta name="theme-color" content="#C4622D">
 </head>
 <body class="p-component">
   <app-root></app-root>

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -5,3 +5,24 @@
 @import "primeicons/primeicons.css";
 
 @tailwind utilities;
+
+/* Guitar Journey Design Tokens */
+:root {
+  --gj-background:    #F5F0E8;
+  --gj-surface:       #FDFAF4;
+  --gj-sidebar:       #4E2A14;
+  --gj-text:          #1C1A16;
+  --gj-muted:         #7A7060;
+  --gj-accent:        #C4622D;
+  --gj-accent-hover:  #A34E22;
+  --gj-accent-text:   #FFFFFF;
+  --gj-border:        #E8E0D0;
+  --gj-sidebar-text:  #F5F0E8;
+  --gj-sidebar-muted: #C4A882;
+}
+
+body {
+  background-color: var(--gj-background);
+  color: var(--gj-text);
+  font-family: 'DM Sans', sans-serif;
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -3,6 +3,24 @@ module.exports = {
   content: [
     "./src/**/*.{html,ts}",
   ],
-  theme: { extend: {} },
+  theme: {
+    extend: {
+      colors: {
+        'gj-background':   'var(--gj-background)',
+        'gj-surface':      'var(--gj-surface)',
+        'gj-sidebar':      'var(--gj-sidebar)',
+        'gj-text':         'var(--gj-text)',
+        'gj-muted':        'var(--gj-muted)',
+        'gj-accent':       'var(--gj-accent)',
+        'gj-accent-hover': 'var(--gj-accent-hover)',
+        'gj-accent-text':  'var(--gj-accent-text)',
+        'gj-border':       'var(--gj-border)',
+      },
+      fontFamily: {
+        display: ['"Cabinet Grotesk"', 'sans-serif'],
+        sans:    ['"DM Sans"', 'sans-serif'],
+      },
+    },
+  },
   plugins: [],
 }


### PR DESCRIPTION
## Summary

- **Resource Library (Rounds 1–4):** Full implementation of session resources — `SessionResource` and `Resource` models, `ResourceService` (Firestore CRUD), `SessionResourcePickerComponent` (add from library or new URL with YouTube oEmbed preview), `SessionResourceComponent` (display with optional remove), wired into the session flow (Before phase picker + During phase display)
- **Design System Baseline:** Applied all DESIGN.md tokens to the codebase — Cabinet Grotesk + DM Sans fonts, `--gj-*` CSS custom properties, burnt sienna PrimeNG Aura preset via `definePreset`, replaced all `indigo-*` Tailwind classes with `--gj-accent`, cream surfaces replacing `bg-white`, hierarchical border radius

## Test plan

- [ ] 294/294 unit tests passing (`npx jest`)
- [ ] Session flow: Before → add a resource via picker → Start → resource visible during session → End → Finish saves session + resources
- [ ] Resource library: existing resources appear in picker dropdown; selecting one populates the session
- [ ] Design: cream background, burnt sienna buttons/accents, Cabinet Grotesk headings, DM Sans body text visible at `localhost:4200`

🤖 Generated with [Claude Code](https://claude.com/claude-code)