### PR TITLE
feat: sidebar layout, design system, and dashboard

### DIFF
--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -13,6 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
       - run: npm ci && npm run build
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ Do not deviate without explicit user approval.
 In QA mode, flag any code that doesn't match DESIGN.md.
 
 Key rules derived from DESIGN.md:
-- Fonts: Cabinet Grotesk (display/hero), DM Sans (body/UI) — never Inter, Roboto, or system-ui as primary
+- Fonts: Wix Madefor Text (display/hero), DM Sans (body/UI) — never Inter, Roboto, or system-ui as primary
 - Accent: #C4622D burnt sienna — not indigo, not purple, no gradient CTAs
 - Background: #F5F0E8 cream — not pure white (#FFFFFF) for app surfaces
 - Sidebar: #4E2A14 leather brown — the Guitar Journey identity

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -14,15 +14,15 @@
 
 ## Typography
 
-- **Display/Hero:** Cabinet Grotesk (variable, 700–800 weight) — quirky grotesque with real character at large sizes; feels like a personal tool, not enterprise software; playful without being cute. Use for: page titles, dashboard stats, the sidebar wordmark.
+- **Display/Hero:** Wix Madefor Text (600–800 weight) — clean grotesque with slightly wider spacing and strong legibility at all sizes. Use for: page titles, dashboard stats, the sidebar wordmark.
 - **Body:** DM Sans (400, 500) — clean, humanist, high legibility at small sizes; warm without being soft. Use for: all body copy, form labels, session notes.
 - **UI/Labels:** DM Sans 500, `text-transform: uppercase; letter-spacing: 0.05em` for section headers (e.g. "RECENT SESSIONS", "YOUR LIBRARY")
 - **Data/Tables:** DM Sans with `font-variant-numeric: tabular-nums` for session durations, stats, time values
 - **Code:** JetBrains Mono (if code display ever needed)
 - **Loading:**
-  - Cabinet Grotesk: available via Fontshare (`api.fontshare.com`) or self-hosted via Fontsource (`@fontsource-variable/cabinet-grotesk`)
-  - DM Sans: Google Fonts or Fontsource (`@fontsource/dm-sans`)
-  - Load: `font-display: swap` on both; subset to Latin
+  - Wix Madefor Text: Google Fonts (`fonts.googleapis.com`) — weights 600, 700, 800
+  - DM Sans: Google Fonts (`fonts.googleapis.com`) — weights 400, 500
+  - Load: `font-display: swap` via Google Fonts stylesheet in `index.html`
 
 - **Scale (8px base, 1.25 modular):**
   ```
@@ -114,6 +114,8 @@
 | 2026-06-11 | Initial design system created via /design-consultation | Based on user brief: "easy to use, encouraging, a little playful without being overly cute; future personalization from serious to whimsical" |
 | 2026-06-11 | Accent: burnt sienna #C4622D (not indigo) | Indigo was a codebase default, not a decision. Burnt sienna is rosewood — guitar-adjacent, warm, distinctive. |
 | 2026-06-11 | Display font: Cabinet Grotesk (not Fraunces serif, not Inter/Roboto) | User chose sans-serif display. Cabinet Grotesk has variable weight and character at large sizes without tipping into cute. |
+| 2026-06-12 | Display font revised: Plus Jakarta Sans (replacing Cabinet Grotesk) | remix-v1.png was rendered with Plus Jakarta Sans (double-story 'a', geometric grotesque). Cabinet Grotesk was correctly implemented but visually differed from the approved mockup. Plus Jakarta Sans matches the approved aesthetic and is not AI-slop (not Inter/Roboto). |
+| 2026-06-12 | Display font revised: Wix Madefor Text (replacing Plus Jakarta Sans) | User preferred Wix Madefor Text's wider spacing over Plus Jakarta Sans. |
 | 2026-06-11 | Body font: DM Sans | Humanist, warm, legible — never fights the content. Replaces Roboto (AI slop default). |
 | 2026-06-11 | Sidebar: leather dark brown #4E2A14 | Approved in remix mockup. Stacked GUITAR/JOURNEY wordmark on leather sidebar gives personal/craftsman identity. |
 | 2026-06-11 | Border radius: hierarchical (cards 8px, buttons 6px, pills full) | Not uniform bubble-radius. Hierarchy signals container vs. action vs. label. |

--- a/angular.json
+++ b/angular.json
@@ -122,8 +122,7 @@
             ],
             "styles": [
               "node_modules/primeicons/primeicons.css",
-              "src/styles.scss",
-              "src/assets/theme.css"
+              "src/styles.scss"
             ],
             "scripts": []
           }

--- a/firebase.json
+++ b/firebase.json
@@ -86,7 +86,7 @@
     ]
   },
   "hosting": {
-    "public": "public",
+    "public": "dist/guitar-practice-journal",
     "ignore": [
       "firebase.json",
       "**/.*",

--- a/src/app/features/dashboard/dashboard.component.html
+++ b/src/app/features/dashboard/dashboard.component.html
@@ -11,9 +11,9 @@
     <a
       routerLink="/app/newSession"
       class="shrink-0 inline-flex items-center gap-2 rounded-md bg-gj-accent text-gj-accent-text
-             px-4 py-2 text-sm font-medium hover:bg-gj-accent-hover transition-colors duration-150"
+             px-4 py-2.5 text-sm font-medium hover:bg-gj-accent-hover transition-colors duration-150"
     >
-      <i class="pi pi-play text-xs"></i>
+      <i class="pi pi-play text-sm"></i>
       Start Session
     </a>
   </div>
@@ -21,38 +21,46 @@
   <!-- ── STAT CARDS ──────────────────────────────────── -->
   <section class="grid grid-cols-2 md:grid-cols-4 gap-4">
 
-    <div class="rounded-lg bg-gj-surface border border-gj-border p-4">
-      <div class="flex items-start justify-between mb-3">
-        <p class="text-xs font-medium uppercase tracking-[0.05em] text-gj-muted">Total Practice Time</p>
-        <i class="pi pi-clock text-gj-muted text-sm"></i>
+    <div class="rounded-lg bg-gj-surface border border-gj-border p-5">
+      <div class="w-10 h-10 rounded-full bg-gj-accent/10 flex items-center justify-center mb-3">
+        <i class="pi pi-clock text-gj-accent text-base"></i>
       </div>
+      <p class="text-xs font-medium text-gj-muted mb-1">Total Practice Time</p>
       <p class="font-display font-extrabold text-2xl text-gj-text">{{ hoursMinutes() }}</p>
-      <p class="text-xs text-gj-muted mt-1">{{ weekTotal() }}m this week</p>
+      @if (weekTotal() > 0) {
+        <p class="text-xs text-gj-muted mt-1">
+          +{{ weekTotal() }}m this week <i class="pi pi-arrow-up text-gj-accent" style="font-size:0.6rem"></i>
+        </p>
+      }
     </div>
 
-    <div class="rounded-lg bg-gj-surface border border-gj-border p-4">
-      <div class="flex items-start justify-between mb-3">
-        <p class="text-xs font-medium uppercase tracking-[0.05em] text-gj-muted">Sessions Completed</p>
-        <i class="pi pi-check-circle text-gj-muted text-sm"></i>
+    <div class="rounded-lg bg-gj-surface border border-gj-border p-5">
+      <div class="w-10 h-10 rounded-full bg-gj-accent/10 flex items-center justify-center mb-3">
+        <i class="pi pi-calendar text-gj-accent text-base"></i>
       </div>
+      <p class="text-xs font-medium text-gj-muted mb-1">Sessions Completed</p>
       <p class="font-display font-extrabold text-2xl text-gj-text">{{ data().totals.sessionCount }}</p>
-      <p class="text-xs text-gj-muted mt-1">{{ data().totals.weekSessionCount }} this week</p>
+      @if (data().totals.weekSessionCount > 0) {
+        <p class="text-xs text-gj-muted mt-1">
+          +{{ data().totals.weekSessionCount }} this week <i class="pi pi-arrow-up text-gj-accent" style="font-size:0.6rem"></i>
+        </p>
+      }
     </div>
 
-    <div class="rounded-lg bg-gj-surface border border-gj-border p-4">
-      <div class="flex items-start justify-between mb-3">
-        <p class="text-xs font-medium uppercase tracking-[0.05em] text-gj-muted">Current Streak</p>
-        <i class="pi pi-bolt text-gj-muted text-sm"></i>
+    <div class="rounded-lg bg-gj-surface border border-gj-border p-5">
+      <div class="w-10 h-10 rounded-full bg-gj-accent/10 flex items-center justify-center mb-3">
+        <i class="pi pi-bolt text-gj-accent text-base"></i>
       </div>
+      <p class="text-xs font-medium text-gj-muted mb-1">Current Streak</p>
       <p class="font-display font-extrabold text-2xl text-gj-text">{{ data().totals.streakDays }}</p>
       <p class="text-xs text-gj-muted mt-1">days in a row</p>
     </div>
 
-    <div class="rounded-lg bg-gj-surface border border-gj-border p-4">
-      <div class="flex items-start justify-between mb-3">
-        <p class="text-xs font-medium uppercase tracking-[0.05em] text-gj-muted">Songs Learned</p>
-        <i class="pi pi-headphones text-gj-muted text-sm"></i>
+    <div class="rounded-lg bg-gj-surface border border-gj-border p-5">
+      <div class="w-10 h-10 rounded-full bg-gj-accent/10 flex items-center justify-center mb-3">
+        <i class="pi pi-star text-gj-accent text-base"></i>
       </div>
+      <p class="text-xs font-medium text-gj-muted mb-1">Songs Learned</p>
       <p class="font-display font-extrabold text-2xl text-gj-text">{{ data().songsLearned }}</p>
       <p class="text-xs text-gj-muted mt-1">in your library</p>
     </div>
@@ -63,9 +71,10 @@
   <section class="rounded-lg bg-gj-surface border border-gj-border overflow-hidden">
 
     <div class="flex items-center justify-between px-5 py-4 border-b border-gj-border">
-      <h2 class="text-xs font-medium uppercase tracking-[0.05em] text-gj-muted">Recent Sessions</h2>
-      <a routerLink="/app/sessions" class="text-xs text-gj-accent hover:underline">
-        View all sessions →
+      <h2 class="text-sm font-semibold text-gj-text">Recent Sessions</h2>
+      <a routerLink="/app/sessions"
+         class="flex items-center gap-1 text-xs text-gj-accent hover:underline">
+        View all sessions <i class="pi pi-chevron-right text-xs"></i>
       </a>
     </div>
 
@@ -82,17 +91,17 @@
           <li [class.border-b]="!last" class="border-gj-border">
             <a
               [routerLink]="['/app/sessions', session.id]"
-              class="flex items-center gap-4 px-5 py-3 hover:bg-gj-background transition-colors duration-150"
+              class="flex items-center gap-4 px-5 py-3.5 hover:bg-gj-background transition-colors duration-150"
             >
               <!-- Icon -->
-              <span class="w-8 h-8 rounded-md bg-gj-background border border-gj-border
+              <span class="w-9 h-9 rounded-full bg-gj-accent/10 border border-gj-accent/20
                            flex items-center justify-center shrink-0">
-                <i class="pi pi-music text-gj-muted text-xs"></i>
+                <i class="pi pi-music text-gj-accent text-sm"></i>
               </span>
 
               <!-- Name + intent -->
               <div class="flex-1 min-w-0">
-                <p class="text-sm font-medium text-gj-text truncate">{{ session.whatToPractice }}</p>
+                <p class="text-sm font-semibold text-gj-text truncate">{{ session.whatToPractice }}</p>
                 <p class="text-xs text-gj-muted truncate">{{ session.sessionIntent }}</p>
               </div>
 
@@ -101,8 +110,8 @@
                 <span class="text-xs text-gj-muted hidden sm:block">
                   {{ session.startedAt | date:'MMM d, y' }}
                 </span>
-                <span class="inline-flex items-center rounded-full bg-gj-accent/10 text-gj-accent
-                             text-xs font-medium px-2.5 py-0.5 tabular-nums">
+                <span class="inline-flex items-center rounded-full bg-gj-accent text-white
+                             text-xs font-semibold px-2.5 py-0.5 tabular-nums">
                   {{ session.durationMs / 60000 | number:'1.0-0' }}m
                 </span>
               </div>

--- a/src/app/features/dashboard/dashboard.component.html
+++ b/src/app/features/dashboard/dashboard.component.html
@@ -1,130 +1,117 @@
-<div class="space-y-8">
-  <!-- Hero Section with Rotating Carousel -->
-  <section class="relative overflow-hidden rounded-lg border bg-[var(--gj-surface)]">
-    <!-- Carousel Image with Attribution Overlay -->
-    <div 
-      class="relative h-[22rem] md:h-[28-rem] w-full bg-cover bg-center"
-      [style.background-image]="currentImage() ? 'url(' + currentImage() + ')' : 'none'"
-      (mouseenter)="onImageMouseEnter()"
-      (mouseleave)="onImageMouseLeave()"
-      role="img"
-      [attr.aria-label]="currentItem()?.alt || 'Inspirational image'"
+<div class="space-y-6 max-w-4xl">
+
+  <!-- ── GREETING ────────────────────────────────────── -->
+  <div class="flex items-start justify-between gap-4">
+    <div>
+      <h1 class="font-display font-extrabold text-3xl text-gj-text leading-tight">
+        Welcome back, guitarist.
+      </h1>
+      <p class="text-gj-muted mt-1 text-sm">Every session moves you forward.</p>
+    </div>
+    <a
+      routerLink="/app/newSession"
+      class="shrink-0 inline-flex items-center gap-2 rounded-md bg-gj-accent text-gj-accent-text
+             px-4 py-2 text-sm font-medium hover:bg-gj-accent-hover transition-colors duration-150"
     >
-      <!-- Attribution Overlay (shown on hover) -->
-      @if (isHovering() && currentItem()) {
-        <div class="absolute inset-0 bg-black bg-opacity-60 flex items-end p-4 transition-opacity duration-300">
-          <div class="text-white text-sm space-y-1">
-            <p class="font-semibold">{{ currentItem()!.attribution.title }}</p>
-            <p class="text-xs opacity-90">
-              by 
-              @if (currentItem()!.attribution.creatorUrl) {
-                <a 
-                  [href]="currentItem()!.attribution.creatorUrl" 
-                  target="_blank" 
-                  rel="noopener noreferrer"
-                  class="underline hover:text-blue-300"
-                >
-                  {{ currentItem()!.attribution.creatorName }}
-                </a>
-              } @else {
-                {{ currentItem()!.attribution.creatorName }}
-              }
-              via
-              <a 
-                [href]="currentItem()!.attribution.sourceUrl" 
-                target="_blank" 
-                rel="noopener noreferrer"
-                class="underline hover:text-blue-300"
-              >
-                {{ currentItem()!.attribution.sourceName }}
-              </a>
-            </p>
-            <p class="text-xs opacity-80">
-              License: 
-              <a 
-                [href]="currentItem()!.attribution.licenseUrl" 
-                target="_blank" 
-                rel="license noopener noreferrer"
-                class="underline hover:text-blue-300"
-              >
-                {{ currentItem()!.attribution.license }}
-              </a>
-              @if (currentItem()!.attribution.changesMade) {
-                <span> — {{ currentItem()!.attribution.changesMade }}</span>
-              }
-            </p>
-          </div>
-        </div>
-      }
+      <i class="pi pi-play text-xs"></i>
+      Start Session
+    </a>
+  </div>
+
+  <!-- ── STAT CARDS ──────────────────────────────────── -->
+  <section class="grid grid-cols-2 md:grid-cols-4 gap-4">
+
+    <div class="rounded-lg bg-gj-surface border border-gj-border p-4">
+      <div class="flex items-start justify-between mb-3">
+        <p class="text-xs font-medium uppercase tracking-[0.05em] text-gj-muted">Total Practice Time</p>
+        <i class="pi pi-clock text-gj-muted text-sm"></i>
+      </div>
+      <p class="font-display font-extrabold text-2xl text-gj-text">{{ hoursMinutes() }}</p>
+      <p class="text-xs text-gj-muted mt-1">{{ weekTotal() }}m this week</p>
     </div>
 
-    <!-- Call-to-Action Section -->
-    <div class="p-6">
-      <h2 class="text-2xl font-semibold mb-1">What do you want to do today?</h2>
-      <p class="text-neutral-600 mb-4">Pick a quick action to jump in.</p>
+    <div class="rounded-lg bg-gj-surface border border-gj-border p-4">
+      <div class="flex items-start justify-between mb-3">
+        <p class="text-xs font-medium uppercase tracking-[0.05em] text-gj-muted">Sessions Completed</p>
+        <i class="pi pi-check-circle text-gj-muted text-sm"></i>
+      </div>
+      <p class="font-display font-extrabold text-2xl text-gj-text">{{ data().totals.sessionCount }}</p>
+      <p class="text-xs text-gj-muted mt-1">{{ data().totals.weekSessionCount }} this week</p>
+    </div>
 
-      <div class="grid gap-3 sm:grid-cols-3">
-        <a 
-          routerLink="/app/newSession" 
-          class="rounded-xl border p-4 hover:bg-neutral-50 transition-colors"
-        >
-          Start a practice session
-        </a>
-        <a 
-          routerLink="/app/songs" 
-          class="rounded-xl border p-4 hover:bg-neutral-50 transition-colors"
-        >
-          Work on a song
-        </a>
-        <a 
-          routerLink="/app/metrics" 
-          class="rounded-xl border p-4 hover:bg-neutral-50 transition-colors"
-        >
-          Review stats
+    <div class="rounded-lg bg-gj-surface border border-gj-border p-4">
+      <div class="flex items-start justify-between mb-3">
+        <p class="text-xs font-medium uppercase tracking-[0.05em] text-gj-muted">Current Streak</p>
+        <i class="pi pi-bolt text-gj-muted text-sm"></i>
+      </div>
+      <p class="font-display font-extrabold text-2xl text-gj-text">{{ data().totals.streakDays }}</p>
+      <p class="text-xs text-gj-muted mt-1">days in a row</p>
+    </div>
+
+    <div class="rounded-lg bg-gj-surface border border-gj-border p-4">
+      <div class="flex items-start justify-between mb-3">
+        <p class="text-xs font-medium uppercase tracking-[0.05em] text-gj-muted">Songs Learned</p>
+        <i class="pi pi-headphones text-gj-muted text-sm"></i>
+      </div>
+      <p class="font-display font-extrabold text-2xl text-gj-text">{{ data().songsLearned }}</p>
+      <p class="text-xs text-gj-muted mt-1">in your library</p>
+    </div>
+
+  </section>
+
+  <!-- ── RECENT SESSIONS ─────────────────────────────── -->
+  <section class="rounded-lg bg-gj-surface border border-gj-border overflow-hidden">
+
+    <div class="flex items-center justify-between px-5 py-4 border-b border-gj-border">
+      <h2 class="text-xs font-medium uppercase tracking-[0.05em] text-gj-muted">Recent Sessions</h2>
+      <a routerLink="/app/sessions" class="text-xs text-gj-accent hover:underline">
+        View all sessions →
+      </a>
+    </div>
+
+    @if (data().recentSessions.length === 0) {
+      <div class="px-5 py-10 text-center">
+        <p class="text-gj-muted text-sm">No sessions yet.</p>
+        <a routerLink="/app/newSession" class="mt-2 inline-block text-sm text-gj-accent hover:underline">
+          Start your first one →
         </a>
       </div>
-    </div>
-  </section>
+    } @else {
+      <ul>
+        @for (session of data().recentSessions; track session.id; let last = $last) {
+          <li [class.border-b]="!last" class="border-gj-border">
+            <a
+              [routerLink]="['/app/sessions', session.id]"
+              class="flex items-center gap-4 px-5 py-3 hover:bg-gj-background transition-colors duration-150"
+            >
+              <!-- Icon -->
+              <span class="w-8 h-8 rounded-md bg-gj-background border border-gj-border
+                           flex items-center justify-center shrink-0">
+                <i class="pi pi-music text-gj-muted text-xs"></i>
+              </span>
 
-  <!-- Stats Cards Section -->
-  <section class="grid gap-6 md:grid-cols-3">
-    <!-- Last Session Card -->
-    <div class="rounded-lg border p-5 bg-[var(--gj-surface)]">
-      <h3 class="font-semibold mb-2">Last session</h3>
-      @if (data().lastSession) {
-        <p class="text-sm text-neutral-600">
-          {{ data().lastSession!.startedAt | date:'short' }} —
-          {{ (data().lastSession!.durationMs/60000) | number:'1.0-0' }} min
-        </p>
-        <a 
-          [routerLink]="['/app/sessions', data().lastSession!.id]" 
-          class="inline-block mt-3 text-[var(--gj-accent)] hover:underline"
-        >
-          View details
-        </a>
-      } @else {
-        <p class="text-sm text-neutral-600">No sessions yet.</p>
-      }
-    </div>
+              <!-- Name + intent -->
+              <div class="flex-1 min-w-0">
+                <p class="text-sm font-medium text-gj-text truncate">{{ session.whatToPractice }}</p>
+                <p class="text-xs text-gj-muted truncate">{{ session.sessionIntent }}</p>
+              </div>
 
-    <!-- Totals Card -->
-    <div class="rounded-lg border p-5 bg-[var(--gj-surface)]">
-      <h3 class="font-semibold mb-2">Totals</h3>
-      <ul class="text-sm text-neutral-700 space-y-1">
-        <li>Total minutes: <strong>{{ data().totals.minutes }}</strong></li>
-        <li>Sessions: <strong>{{ data().totals.sessionCount }}</strong></li>
-        <li>Streak: <strong>{{ data().totals.streakDays }} days</strong></li>
+              <!-- Date + duration badge -->
+              <div class="flex items-center gap-3 shrink-0">
+                <span class="text-xs text-gj-muted hidden sm:block">
+                  {{ session.startedAt | date:'MMM d, y' }}
+                </span>
+                <span class="inline-flex items-center rounded-full bg-gj-accent/10 text-gj-accent
+                             text-xs font-medium px-2.5 py-0.5 tabular-nums">
+                  {{ session.durationMs / 60000 | number:'1.0-0' }}m
+                </span>
+              </div>
+            </a>
+          </li>
+        }
       </ul>
-    </div>
+    }
 
-    <!-- This Week Card -->
-    <div class="rounded-lg border p-5 bg-[var(--gj-surface)]">
-      <h3 class="font-semibold mb-2">This week</h3>
-      <p class="text-sm text-neutral-600">
-        {{ weekTotal() }} minutes so far.
-      </p>
-      <!-- Placeholder for future sparkline/chart -->
-      <div class="mt-3 h-16 rounded bg-neutral-100"></div>
-    </div>
   </section>
+
 </div>

--- a/src/app/features/dashboard/dashboard.component.spec.ts
+++ b/src/app/features/dashboard/dashboard.component.spec.ts
@@ -50,12 +50,16 @@ describe('DashboardComponent', () => {
       id: 'last-1',
       startedAt: new Date('2025-09-08T14:00:00-04:00'),
       durationMs: 45 * 60_000,
+      whatToPractice: 'Chord changes',
+      sessionIntent: 'Clean transitions',
     },
-    totals: { minutes: 120, sessionCount: 3, streakDays: 2 },
+    recentSessions: [],
+    totals: { minutes: 120, sessionCount: 3, streakDays: 2, weekSessionCount: 1 },
     week: {
       '2025-09-08': 15,
       '2025-09-09': 45,
     },
+    songsLearned: 0,
   };
 
   let mockCarouselService: { getCarouselItems: jest.Mock };
@@ -89,8 +93,10 @@ describe('DashboardComponent', () => {
               dashboard: fixtureData
                 ? ({
                     lastSession: fixtureData.lastSession ?? DASHBOARD.lastSession,
+                    recentSessions: fixtureData.recentSessions ?? DASHBOARD.recentSessions,
                     totals: fixtureData.totals ?? DASHBOARD.totals,
                     week: fixtureData.week ?? DASHBOARD.week,
+                    songsLearned: fixtureData.songsLearned ?? DASHBOARD.songsLearned,
                   } as DashboardData)
                 : (DASHBOARD as DashboardData),
             }),
@@ -124,6 +130,16 @@ describe('DashboardComponent', () => {
   it('computes weekTotal from week record', () => {
     const { cmp } = create();
     expect(cmp.weekTotal()).toBe(15 + 45);
+  });
+
+  it('formats hoursMinutes as Xh Ym when total >= 60 minutes', () => {
+    const { cmp } = create({ fixtureData: { totals: { minutes: 90, sessionCount: 3, streakDays: 2, weekSessionCount: 1 } } });
+    expect(cmp.hoursMinutes()).toBe('1h 30m');
+  });
+
+  it('formats hoursMinutes as Ym when total < 60 minutes', () => {
+    const { cmp } = create({ fixtureData: { totals: { minutes: 45, sessionCount: 3, streakDays: 2, weekSessionCount: 1 } } });
+    expect(cmp.hoursMinutes()).toBe('45m');
   });
 
   it('returns 0 weekTotal when week is empty/undefined', () => {
@@ -164,17 +180,12 @@ describe('DashboardComponent', () => {
       expect(cmp.carouselItems()).toHaveLength(2);
     });
 
-    it('logs error and keeps items empty when load fails', async () => {
-      const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+    it('keeps items empty when load fails (carousel is optional — fails silently)', async () => {
       const { fixture, cmp } = create({ carouselError: new Error('network') });
 
       await flushPromises();
       fixture.detectChanges();
 
-      expect(consoleSpy).toHaveBeenCalledWith(
-        'Failed to load carousel items:',
-        expect.any(Error),
-      );
       expect(cmp.carouselItems()).toHaveLength(0);
     });
   });

--- a/src/app/features/dashboard/dashboard.component.ts
+++ b/src/app/features/dashboard/dashboard.component.ts
@@ -5,12 +5,14 @@ import { toSignal } from '@angular/core/rxjs-interop';
 import { map } from 'rxjs/operators';
 import { DashboardData } from './dashboard.resolver';
 import { CarouselService } from '../../services/carousel.service';
-import { CarouselItem } from '../../models/carousel'; // Ensure this file exists at the specified path
+import { CarouselItem } from '../../models/carousel';
 
 const EMPTY_DASHBOARD: DashboardData = {
   lastSession: undefined,
-  totals: { minutes: 0, sessionCount: 0, streakDays: 0 },
+  recentSessions: [],
+  totals: { minutes: 0, sessionCount: 0, streakDays: 0, weekSessionCount: 0 },
   week: {} as Record<string, number>,
+  songsLearned: 0,
 };
 
 @Component({
@@ -18,13 +20,11 @@ const EMPTY_DASHBOARD: DashboardData = {
   standalone: true,
   imports: [CommonModule, RouterLink, DatePipe, DecimalPipe],
   templateUrl: './dashboard.component.html',
-
 })
 export class DashboardComponent implements OnDestroy {
   private route = inject(ActivatedRoute);
   private carouselService: CarouselService = inject(CarouselService);
 
-  // Dashboard data from resolver
   readonly data = toSignal(
     this.route.data.pipe(
       map(d => (d['dashboard'] as DashboardData) ?? EMPTY_DASHBOARD)
@@ -32,48 +32,40 @@ export class DashboardComponent implements OnDestroy {
     { initialValue: EMPTY_DASHBOARD }
   );
 
-  // Week total computed from dashboard data
   weekTotal = computed(() => {
     const w = this.data().week as Record<string, number> | undefined;
     if (!w) return 0;
-    const vals = Object.values(w) as number[];
-    return vals.reduce((a, b) => a + b, 0);
+    return (Object.values(w) as number[]).reduce((a, b) => a + b, 0);
   });
 
-  // Carousel state
+  hoursMinutes = computed(() => {
+    const mins = this.data().totals.minutes;
+    const h = Math.floor(mins / 60);
+    const m = mins % 60;
+    return h > 0 ? `${h}h ${m}m` : `${m}m`;
+  });
+
+  // Carousel state (retained for future use; not rendered in current template)
   carouselItems = signal<CarouselItem[]>([]);
   currentIndex = signal(0);
   isHovering = signal(false);
   private rotationInterval?: number;
 
-  // Current carousel item (computed)
   currentItem = computed(() => {
     const items = this.carouselItems();
-    const index = this.currentIndex();
-    return items.length > 0 ? items[index] : null;
+    return items.length > 0 ? items[this.currentIndex()] : null;
   });
 
-  // Current image URL (computed)
   currentImage = computed(() => {
     const item = this.currentItem();
     if (!item) return '';
-    
-    // Prefer WebP medium variant, fall back to URL
-    return item.image.variants?.webpMd || 
-           item.image.variants?.md || 
-           item.image.url;
+    return item.image.variants?.webpMd || item.image.variants?.md || item.image.url;
   });
 
   constructor() {
-    // Load carousel items
     this.loadCarousel();
-
-    // Start rotation effect
     effect(() => {
-      const items = this.carouselItems();
-      if (items.length > 0) {
-        this.startRotation();
-      }
+      if (this.carouselItems().length > 0) this.startRotation();
     });
   }
 
@@ -85,23 +77,16 @@ export class DashboardComponent implements OnDestroy {
     try {
       const items = await this.carouselService.getCarouselItems('dashboard-hero');
       this.carouselItems.set(items);
-    } catch (error) {
-      console.error('Failed to load carousel items:', error);
-      // Could set a fallback or show error state
+    } catch {
+      // carousel is optional — fail silently
     }
   }
 
   private startRotation(): void {
-    this.stopRotation(); // Clear any existing interval
-
-    const items = this.carouselItems();
-    if (items.length <= 1) return; // No rotation needed for single item
-
-    // Default rotation interval: 12 seconds (12000ms)
-    // You could pull this from Firestore carousel config if needed
+    this.stopRotation();
+    if (this.carouselItems().length <= 1) return;
     this.rotationInterval = window.setInterval(() => {
-      const nextIndex = (this.currentIndex() + 1) % items.length;
-      this.currentIndex.set(nextIndex);
+      this.currentIndex.set((this.currentIndex() + 1) % this.carouselItems().length);
     }, 12000);
   }
 
@@ -112,27 +97,18 @@ export class DashboardComponent implements OnDestroy {
     }
   }
 
-  // Manual navigation (for optional prev/next buttons)
   nextImage(): void {
     const items = this.carouselItems();
     if (items.length === 0) return;
-    const nextIndex = (this.currentIndex() + 1) % items.length;
-    this.currentIndex.set(nextIndex);
+    this.currentIndex.set((this.currentIndex() + 1) % items.length);
   }
 
   prevImage(): void {
     const items = this.carouselItems();
     if (items.length === 0) return;
-    const prevIndex = (this.currentIndex() - 1 + items.length) % items.length;
-    this.currentIndex.set(prevIndex);
+    this.currentIndex.set((this.currentIndex() - 1 + items.length) % items.length);
   }
 
-  // Hover state management for attribution overlay
-  onImageMouseEnter(): void {
-    this.isHovering.set(true);
-  }
-
-  onImageMouseLeave(): void {
-    this.isHovering.set(false);
-  }
+  onImageMouseEnter(): void { this.isHovering.set(true); }
+  onImageMouseLeave(): void { this.isHovering.set(false); }
 }

--- a/src/app/features/dashboard/dashboard.resolver.spec.ts
+++ b/src/app/features/dashboard/dashboard.resolver.spec.ts
@@ -69,13 +69,16 @@ describe('DashboardResolver', () => {
     (authState as jest.Mock).mockReturnValue(of({ uid: 'u1' }));
 
     // Three sessions: Mon(9/08)=30m (today), Sun(9/07)=20m, Sat(9/06)=10m
-    (getDocs as jest.Mock).mockResolvedValue({
-      docs: [
-        mkDoc('a', '2025-09-08', 30), // latest
-        mkDoc('b', '2025-09-07', 20),
-        mkDoc('c', '2025-09-06', 10),
-      ],
-    });
+    // Second getDocs call is for the songs collection (returns size)
+    (getDocs as jest.Mock)
+      .mockResolvedValueOnce({
+        docs: [
+          mkDoc('a', '2025-09-08', 30), // latest
+          mkDoc('b', '2025-09-07', 20),
+          mkDoc('c', '2025-09-06', 10),
+        ],
+      })
+      .mockResolvedValueOnce({ size: 5 });
 
     const resolver = TestBed.inject(DashboardResolver);
     const data = await resolver.resolve();
@@ -96,11 +99,14 @@ describe('DashboardResolver', () => {
     expect(weekSum).toBe(30);
 
     // Ensure we actually used the query helpers (coverage of those call sites)
-    expect(collection).toHaveBeenCalledTimes(1);
+    // collection is called twice: once for sessions, once for songs
+    expect(collection).toHaveBeenCalledTimes(2);
     expect(orderBy).toHaveBeenCalledWith('date', 'desc');
     expect(limit).toHaveBeenCalledWith(365);
     expect(query).toHaveBeenCalledTimes(1);
-    expect(getDocs).toHaveBeenCalledTimes(1);
+    // getDocs is called twice: sessions query + songs collection
+    expect(getDocs).toHaveBeenCalledTimes(2);
+    expect(data.songsLearned).toBe(5);
   });
 
   it('throws when there is no authed user (authState emits null)', async () => {

--- a/src/app/features/dashboard/dashboard.resolver.ts
+++ b/src/app/features/dashboard/dashboard.resolver.ts
@@ -1,5 +1,5 @@
 // dashboard.resolver.ts
-import { Injectable, inject } from '@angular/core';
+import { Injectable, inject, EnvironmentInjector, runInInjectionContext } from '@angular/core';
 import { Resolve } from '@angular/router';
 import { collection, Firestore, getDocs, limit, orderBy, query } from '@angular/fire/firestore';
 import { Session } from '@models/session';
@@ -27,14 +27,17 @@ export interface DashboardData {
 export class DashboardResolver implements Resolve<DashboardData> {
   private fs = inject(Firestore);
   private auth = inject(Auth);
+  private injector = inject(EnvironmentInjector);
+  // authState() must be called in injection context — do it at class-init time
+  private readonly authState$ = authState(this.auth).pipe(filter(Boolean));
 
   async resolve(): Promise<DashboardData> {
-    const user = await firstValueFrom(authState(this.auth).pipe(filter(Boolean), take(1)));
+    const user = await firstValueFrom(this.authState$.pipe(take(1)));
     const uid = user!.uid;
 
     const ref = collection(this.fs, `users/${uid}/sessions`).withConverter(sessionConverter);
     const q = query(ref, orderBy('date', 'desc'), limit(365));
-    const snap = await getDocs(q);
+    const snap = await runInInjectionContext(this.injector, () => getDocs(q));
 
     const sessions: ViewSession[] = snap.docs.map(d => {
       const s = d.data() as Session;
@@ -89,7 +92,7 @@ export class DashboardResolver implements Resolve<DashboardData> {
 
     // Songs learned
     const songsRef = collection(this.fs, `users/${uid}/songs`);
-    const songsSnap = await getDocs(songsRef);
+    const songsSnap = await runInInjectionContext(this.injector, () => getDocs(songsRef));
     const songsLearned = songsSnap.size;
 
     return {

--- a/src/app/features/dashboard/dashboard.resolver.ts
+++ b/src/app/features/dashboard/dashboard.resolver.ts
@@ -7,13 +7,20 @@ import { sessionConverter } from '../../storage/converters';
 import { Auth, authState } from '@angular/fire/auth';
 import { filter, firstValueFrom, take } from 'rxjs';
 
+export interface ViewSession {
+  id: string;
+  startedAt: Date;
+  durationMs: number;
+  whatToPractice: string;
+  sessionIntent: string;
+}
 
-
-export interface ViewSession { id: string; startedAt: Date; durationMs: number; }
 export interface DashboardData {
   lastSession?: ViewSession;
-  totals: { minutes: number; sessionCount: number; streakDays: number; };
+  recentSessions: ViewSession[];
+  totals: { minutes: number; sessionCount: number; streakDays: number; weekSessionCount: number; };
   week: Record<string, number>;
+  songsLearned: number;
 }
 
 @Injectable({ providedIn: 'root' })
@@ -31,18 +38,25 @@ export class DashboardResolver implements Resolve<DashboardData> {
 
     const sessions: ViewSession[] = snap.docs.map(d => {
       const s = d.data() as Session;
-      return { id: d.id, startedAt: s.date.toDate(), durationMs: Math.round((s.practiceTime ?? 0) * 60000) };
+      return {
+        id: d.id,
+        startedAt: s.date.toDate(),
+        durationMs: Math.round((s.practiceTime ?? 0) * 60000),
+        whatToPractice: s.whatToPractice ?? '',
+        sessionIntent: s.sessionIntent ?? '',
+      };
     });
 
     const lastSession = sessions[0];
+    const recentSessions = sessions.slice(0, 5);
     const minutes = Math.round(sessions.reduce((acc, s) => acc + s.durationMs / 60000, 0));
     const sessionCount = sessions.length;
 
-    // streak + week same as before (omitted here for brevity) ...
     const tz = 'America/New_York';
     const toLocalYmd = (dt: Date) =>
       new Intl.DateTimeFormat('en-CA', { timeZone: tz, year: 'numeric', month: '2-digit', day: '2-digit' }).format(dt);
 
+    // Streak
     const days = new Set(sessions.map(s => toLocalYmd(s.startedAt)));
     let streakDays = 0;
     let cur = new Date();
@@ -50,6 +64,7 @@ export class DashboardResolver implements Resolve<DashboardData> {
       while (days.has(toLocalYmd(cur))) { streakDays++; cur.setUTCDate(cur.getUTCDate() - 1); }
     }
 
+    // Week
     const week: Record<string, number> = {};
     const startOfWeek = (() => {
       const local = new Date(`${toLocalYmd(new Date())}T00:00:00`);
@@ -60,9 +75,29 @@ export class DashboardResolver implements Resolve<DashboardData> {
       start.setDate(local.getDate() - deltaToMon);
       return start;
     })();
-    for (let i = 0; i < 7; i++) { const d = new Date(startOfWeek); d.setDate(startOfWeek.getDate() + i); week[toLocalYmd(d)] = 0; }
-    sessions.forEach(s => { const ymd = toLocalYmd(s.startedAt); if (ymd in week) week[ymd] += Math.round(s.durationMs / 60000); });
+    for (let i = 0; i < 7; i++) {
+      const d = new Date(startOfWeek);
+      d.setDate(startOfWeek.getDate() + i);
+      week[toLocalYmd(d)] = 0;
+    }
+    sessions.forEach(s => {
+      const ymd = toLocalYmd(s.startedAt);
+      if (ymd in week) week[ymd] += Math.round(s.durationMs / 60000);
+    });
 
-    return { lastSession, totals: { minutes, sessionCount, streakDays }, week };
+    const weekSessionCount = sessions.filter(s => toLocalYmd(s.startedAt) in week).length;
+
+    // Songs learned
+    const songsRef = collection(this.fs, `users/${uid}/songs`);
+    const songsSnap = await getDocs(songsRef);
+    const songsLearned = songsSnap.size;
+
+    return {
+      lastSession,
+      recentSessions,
+      totals: { minutes, sessionCount, streakDays, weekSessionCount },
+      week,
+      songsLearned,
+    };
   }
 }

--- a/src/app/shells/app-shell.component.html
+++ b/src/app/shells/app-shell.component.html
@@ -2,29 +2,41 @@
 
   <!-- ── SIDEBAR ─────────────────────────────────────── -->
   <aside
-    class="flex flex-col flex-shrink-0 bg-gj-sidebar overflow-hidden transition-[width] duration-300 ease-in-out"
+    class="relative flex flex-col flex-shrink-0 bg-gj-sidebar overflow-hidden transition-[width] duration-300 ease-in-out"
     [style.width.px]="collapsed() ? 56 : 220"
+    style="box-shadow: inset 0 0 0 6px rgba(255,255,255,0.06), inset 0 0 0 8px rgba(0,0,0,0.18);"
   >
 
+    <!-- Leather grain texture -->
+    <svg class="absolute inset-0 w-full h-full pointer-events-none" aria-hidden="true"
+         xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice">
+      <filter id="gj-grain">
+        <feTurbulence type="fractalNoise" baseFrequency="0.65 0.65" numOctaves="3" stitchTiles="stitch"/>
+        <feColorMatrix type="saturate" values="0"/>
+      </filter>
+      <rect width="100%" height="100%" filter="url(#gj-grain)" opacity="0.07"/>
+    </svg>
+
     <!-- Wordmark -->
-    <div class="flex items-center justify-center py-6 px-3 select-none shrink-0">
+    <div class="relative flex items-center justify-center py-7 px-3 select-none shrink-0
+                border-b border-white/10">
       @if (!collapsed()) {
         <div class="text-center leading-tight">
-          <div class="font-display font-extrabold text-sm tracking-[0.2em] uppercase text-gj-sidebar-text">
+          <div class="font-display font-extrabold text-xl tracking-[0.25em] uppercase text-gj-sidebar-text">
             Guitar
           </div>
           <div class="text-gj-sidebar-muted text-xs my-1">♦</div>
-          <div class="font-display font-extrabold text-sm tracking-[0.2em] uppercase text-gj-sidebar-text">
+          <div class="font-display font-extrabold text-xl tracking-[0.25em] uppercase text-gj-sidebar-text">
             Journey
           </div>
         </div>
       } @else {
-        <div class="font-display font-extrabold text-xs tracking-widest text-gj-sidebar-text">GJ</div>
+        <div class="font-display font-extrabold text-sm tracking-widest text-gj-sidebar-text">GJ</div>
       }
     </div>
 
     <!-- Nav -->
-    <nav class="flex-1 flex flex-col gap-1 px-2">
+    <nav class="relative flex-1 flex flex-col gap-1 px-2 pt-2">
       @for (item of navItems; track item.route) {
         <a
           [routerLink]="item.route"
@@ -46,7 +58,7 @@
     </nav>
 
     <!-- Footer -->
-    <div class="shrink-0 px-2 pb-4 pt-3 border-t border-white/10">
+    <div class="relative shrink-0 px-2 pb-4 pt-3 border-t border-white/10">
       <button
         type="button"
         (click)="toggleSidebar()"

--- a/src/app/shells/app-shell.component.html
+++ b/src/app/shells/app-shell.component.html
@@ -18,20 +18,20 @@
     </svg>
 
     <!-- Wordmark -->
-    <div class="relative flex items-center justify-center py-7 px-3 select-none shrink-0
+    <div class="relative flex items-center justify-center min-h-[25vh] px-3 select-none shrink-0
                 border-b border-white/10">
       @if (!collapsed()) {
         <div class="text-center leading-tight">
-          <div class="font-display font-extrabold text-xl tracking-[0.25em] uppercase text-gj-sidebar-text">
+          <div class="font-display font-extrabold text-2xl tracking-[0.25em] uppercase text-gj-sidebar-text">
             Guitar
           </div>
-          <div class="text-gj-sidebar-muted text-xs my-1">♦</div>
-          <div class="font-display font-extrabold text-xl tracking-[0.25em] uppercase text-gj-sidebar-text">
+          <div class="text-gj-sidebar-muted text-sm my-2">♦</div>
+          <div class="font-display font-extrabold text-2xl tracking-[0.25em] uppercase text-gj-sidebar-text">
             Journey
           </div>
         </div>
       } @else {
-        <div class="font-display font-extrabold text-sm tracking-widest text-gj-sidebar-text">GJ</div>
+        <div class="font-display font-extrabold text-base tracking-widest text-gj-sidebar-text">GJ</div>
       }
     </div>
 

--- a/src/app/shells/app-shell.component.html
+++ b/src/app/shells/app-shell.component.html
@@ -1,33 +1,83 @@
-<!-- Sticky top bar -->
-<header class="sticky top-0 z-50 bg-[var(--gj-surface)]/90 backdrop-blur border-b border-[var(--gj-border)]">
-    <div class="mx-auto max-w-6xl px-4">
-      <p-menubar [model]="items()">
-        <ng-template pTemplate="start">
-          <a routerLink="/" class="font-semibold text-neutral-900 hover:opacity-80">Guitar Journey</a>
-        </ng-template>
-  
-        <ng-template pTemplate="end">
-          <p-button
-            label="Account"
-            icon="pi pi-user"
-            styleClass="p-button-text"
-            (onClick)="toggleUserMenu($event)"
-          ></p-button>
-  
-          <!-- Popup TieredMenu for user actions -->
-          <p-tieredMenu
-            #userMenu
-            [model]="userItems()"
-            [popup]="true"
-            appendTo="body"
-          ></p-tieredMenu>
-        </ng-template>
-      </p-menubar>
+<div class="flex h-screen overflow-hidden">
+
+  <!-- ── SIDEBAR ─────────────────────────────────────── -->
+  <aside
+    class="flex flex-col flex-shrink-0 bg-gj-sidebar overflow-hidden transition-[width] duration-300 ease-in-out"
+    [style.width.px]="collapsed() ? 56 : 220"
+  >
+
+    <!-- Wordmark -->
+    <div class="flex items-center justify-center py-6 px-3 select-none shrink-0">
+      @if (!collapsed()) {
+        <div class="text-center leading-tight">
+          <div class="font-display font-extrabold text-sm tracking-[0.2em] uppercase text-gj-sidebar-text">
+            Guitar
+          </div>
+          <div class="text-gj-sidebar-muted text-xs my-1">♦</div>
+          <div class="font-display font-extrabold text-sm tracking-[0.2em] uppercase text-gj-sidebar-text">
+            Journey
+          </div>
+        </div>
+      } @else {
+        <div class="font-display font-extrabold text-xs tracking-widest text-gj-sidebar-text">GJ</div>
+      }
     </div>
-  </header>
-  
-  <!-- Page content -->
-  <main class="mx-auto max-w-6xl px-4 py-6">
+
+    <!-- Nav -->
+    <nav class="flex-1 flex flex-col gap-1 px-2">
+      @for (item of navItems; track item.route) {
+        <a
+          [routerLink]="item.route"
+          routerLinkActive
+          #rla="routerLinkActive"
+          [routerLinkActiveOptions]="{ exact: false }"
+          [ngClass]="rla.isActive
+            ? 'bg-gj-accent text-gj-accent-text'
+            : 'text-gj-sidebar-text hover:bg-white/10'"
+          class="flex items-center gap-3 px-3 py-2 rounded-md text-sm font-medium transition-colors duration-150"
+          [attr.title]="collapsed() ? item.label : null"
+        >
+          <i [class]="item.icon + ' text-base shrink-0'"></i>
+          @if (!collapsed()) {
+            <span>{{ item.label }}</span>
+          }
+        </a>
+      }
+    </nav>
+
+    <!-- Footer -->
+    <div class="shrink-0 px-2 pb-4 pt-3 border-t border-white/10">
+      <button
+        type="button"
+        (click)="toggleSidebar()"
+        class="flex items-center gap-3 w-full px-3 py-2 rounded-md text-sm font-medium
+               text-gj-sidebar-muted hover:bg-white/10 transition-colors duration-150 mb-1"
+        [attr.title]="collapsed() ? 'Expand sidebar' : null"
+      >
+        <i [class]="(collapsed() ? 'pi pi-chevron-right' : 'pi pi-chevron-left') + ' text-base shrink-0'"></i>
+        @if (!collapsed()) {
+          <span>Collapse</span>
+        }
+      </button>
+
+      <button
+        type="button"
+        (click)="onSignOut()"
+        class="flex items-center gap-3 w-full px-3 py-2 rounded-md text-sm font-medium
+               text-gj-sidebar-muted hover:bg-white/10 transition-colors duration-150"
+        [attr.title]="collapsed() ? 'Sign out' : null"
+      >
+        <i class="pi pi-sign-out text-base shrink-0"></i>
+        @if (!collapsed()) {
+          <span>Sign out</span>
+        }
+      </button>
+    </div>
+  </aside>
+
+  <!-- ── MAIN ───────────────────────────────────────── -->
+  <main class="flex-1 min-w-0 overflow-y-auto p-6 bg-gj-background">
     <router-outlet />
   </main>
-  
+
+</div>

--- a/src/app/shells/app-shell.component.ts
+++ b/src/app/shells/app-shell.component.ts
@@ -1,39 +1,36 @@
-import { Component, signal, ViewChild, inject } from '@angular/core';
-import { Router, RouterOutlet } from '@angular/router';
-import { MenuItem } from 'primeng/api';
-import { MenubarModule } from 'primeng/menubar';
-import { TieredMenu, TieredMenuModule } from 'primeng/tieredmenu';
-import { ButtonModule } from 'primeng/button';
+import { Component, signal, inject } from '@angular/core';
+import { Router, RouterLink, RouterLinkActive, RouterOutlet } from '@angular/router';
+import { NgClass } from '@angular/common';
 import { Auth, signOut } from '@angular/fire/auth';
+
+interface NavItem {
+  label: string;
+  icon: string;
+  route: string;
+}
 
 @Component({
   selector: 'app-shell',
   standalone: true,
-  imports: [RouterOutlet, MenubarModule, TieredMenuModule, ButtonModule ],
+  imports: [NgClass, RouterOutlet, RouterLink, RouterLinkActive],
   templateUrl: './app-shell.component.html',
-
 })
 export class AppShellComponent {
-  @ViewChild('userMenu') userMenu!: TieredMenu;
-
-  // Top-level nav
-  readonly items = signal<MenuItem[]>([
-    { label: 'Home',     icon: 'pi pi-home', routerLink: ['dashboard'] },
-    { label: 'Sessions', icon: 'pi pi-clock', routerLink: ['sessions'] },
-    { label: 'Songs',    icon: 'pi pi-headphones', routerLink: ['songs'] },
-    { label: 'Metrics',  icon: 'pi pi-chart-bar', routerLink: ['metrics'] },
-  ]);
-
-  // User dropdown items
-  readonly userItems = signal<MenuItem[]>([
-    { label: 'My Profile', icon: 'pi pi-user',   routerLink: ['/profile'] },
-    { label: 'Settings',   icon: 'pi pi-cog',    routerLink: ['/settings'] },
-    { separator: true },
-    { label: 'Sign out',   icon: 'pi pi-sign-out', command: () => this.onSignOut() },
-  ]);
-
   private readonly auth = inject(Auth);
   private readonly router = inject(Router);
+
+  collapsed = signal(false);
+
+  readonly navItems: NavItem[] = [
+    { label: 'Dashboard', icon: 'pi pi-home',        route: '/app/dashboard' },
+    { label: 'Sessions',  icon: 'pi pi-clock',       route: '/app/sessions'  },
+    { label: 'Songs',     icon: 'pi pi-headphones',  route: '/app/songs'     },
+    { label: 'Metrics',   icon: 'pi pi-chart-bar',   route: '/app/metrics'   },
+  ];
+
+  toggleSidebar() {
+    this.collapsed.update(v => !v);
+  }
 
   async onSignOut() {
     try {
@@ -41,9 +38,5 @@ export class AppShellComponent {
     } finally {
       this.router.navigate(['/']);
     }
-  }
-
-  toggleUserMenu(event: Event) {
-    this.userMenu.toggle(event);
   }
 }

--- a/src/app/shells/app-shell.component.ts
+++ b/src/app/shells/app-shell.component.ts
@@ -23,9 +23,8 @@ export class AppShellComponent {
 
   readonly navItems: NavItem[] = [
     { label: 'Dashboard', icon: 'pi pi-home',        route: '/app/dashboard' },
-    { label: 'Sessions',  icon: 'pi pi-clock',       route: '/app/sessions'  },
-    { label: 'Songs',     icon: 'pi pi-headphones',  route: '/app/songs'     },
-    { label: 'Metrics',   icon: 'pi pi-chart-bar',   route: '/app/metrics'   },
+    { label: 'Sessions',  icon: 'pi pi-calendar',    route: '/app/sessions'  },
+    { label: 'Library',   icon: 'pi pi-book',        route: '/app/songs'     },
   ];
 
   toggleSidebar() {

--- a/src/index.html
+++ b/src/index.html
@@ -6,12 +6,11 @@
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
-  <!-- Cabinet Grotesk — display/hero font -->
-  <link href="https://api.fontshare.com/v2/css?f[]=cabinet-grotesk@700,800&display=swap" rel="stylesheet">
-  <!-- DM Sans — body/UI font -->
-  <link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500&display=swap" rel="stylesheet">
   <link rel="manifest" href="manifest.webmanifest">
   <meta name="theme-color" content="#C4622D">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500&family=Wix+Madefor+Text:wght@600;700;800&display=swap" rel="stylesheet">
 </head>
 <body class="p-component">
   <app-root></app-root>

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,4 +1,5 @@
 /* You can add global styles to this file, and also import other style files */
+
 @tailwind base;
 @tailwind components;
 
@@ -6,7 +7,7 @@
 
 @tailwind utilities;
 
-/* Guitar Journey Design Tokens */
+/* ── Guitar Journey Design Tokens ───────────────────────────── */
 :root {
   --gj-background:    #F5F0E8;
   --gj-surface:       #FDFAF4;
@@ -19,10 +20,17 @@
   --gj-border:        #E8E0D0;
   --gj-sidebar-text:  #F5F0E8;
   --gj-sidebar-muted: #C4A882;
+
+  --p-font-family: 'DM Sans', sans-serif;
 }
 
+/* ── Base typography ─────────────────────────────────────────── */
 body {
   background-color: var(--gj-background);
   color: var(--gj-text);
   font-family: 'DM Sans', sans-serif;
+}
+
+h1, h2, h3, h4, h5, h6 {
+  font-family: 'Wix Madefor Text', sans-serif;
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -15,9 +15,11 @@ module.exports = {
         'gj-accent-hover': 'var(--gj-accent-hover)',
         'gj-accent-text':  'var(--gj-accent-text)',
         'gj-border':       'var(--gj-border)',
+        'gj-sidebar-text': 'var(--gj-sidebar-text)',
+        'gj-sidebar-muted':'var(--gj-sidebar-muted)',
       },
       fontFamily: {
-        display: ['"Cabinet Grotesk"', 'sans-serif'],
+        display: ['"Wix Madefor Text"', 'sans-serif'],
         sans:    ['"DM Sans"', 'sans-serif'],
       },
     },


### PR DESCRIPTION
## Summary

- **Sidebar shell** — collapsible leather sidebar (56px / 220px) with stacked GUITAR/JOURNEY wordmark (25vh), diamond separator, active nav highlight, collapse toggle, and sign-out button
- **Design system** — established `--gj-*` CSS custom properties (burnt sienna accent, cream background, leather sidebar), Tailwind token mapping, Wix Madefor Text (display) + DM Sans (body) via Google Fonts CDN; documented in `DESIGN.md`
- **Dashboard resolver** — fixed "Firebase API called outside injection context" errors; `authState()` hoisted to class property, `getDocs()` calls wrapped in `runInInjectionContext()`
- **Font cleanup** — removed self-hosted woff2 files and `@font-face` blocks; replaced with a single Google Fonts `<link>`; final font choice: Wix Madefor Text

## Test plan

- [ ] App loads at `/app/dashboard` with no console errors
- [ ] Sidebar expands/collapses; active route highlighted; wordmark occupies ~25% of sidebar height
- [ ] Dashboard data loads (sessions, stats, songs learned)
- [ ] Computed `font-family` on headings resolves to `Wix Madefor Text`; body to `DM Sans`
- [ ] Sign-out button works

🤖 Generated with [Claude Code](https://claude.com/claude-code)