### PR TITLE
Technical updates: Firebase fixes, resource picker redesign, and test coverage to 96%

### DIFF
--- a/src/app/auth/auth.service.ts
+++ b/src/app/auth/auth.service.ts
@@ -1,5 +1,5 @@
 // src/app/auth/auth.service.ts
-import { Injectable, computed, inject, signal } from '@angular/core';
+import { Injectable, computed, inject, signal, EnvironmentInjector, runInInjectionContext } from '@angular/core';
 import {
   Auth,
   User,
@@ -17,6 +17,7 @@ import { from } from 'rxjs';
 @Injectable({ providedIn: 'root' })
 export class AuthService {
   private auth = inject(Auth);
+  private injector = inject(EnvironmentInjector);
   private _user = signal<User | null>(null);
   /** Current Firebase user (signal) */
   readonly user = computed(() => this._user());
@@ -28,19 +29,18 @@ export class AuthService {
   /** Google OAuth sign-in (popup) */
   signInWithGoogle() {
     const provider = new GoogleAuthProvider();
-    return from(signInWithPopup(this.auth, provider));
+    return from(runInInjectionContext(this.injector, () => signInWithPopup(this.auth, provider)));
   }
 
   signInWithEmail(email: string, password: string) {
-    return from(signInWithEmailAndPassword(this.auth, email, password));
+    return from(runInInjectionContext(this.injector, () => signInWithEmailAndPassword(this.auth, email, password)));
   }
+
   /** Create account with email + password (optional displayName) */
   async registerWithEmail(email: string, password: string, displayName?: string) {
-    const cred = await createUserWithEmailAndPassword(this.auth, email, password);
+    const cred = await runInInjectionContext(this.injector, () => createUserWithEmailAndPassword(this.auth, email, password));
     if (displayName) {
       await updateProfile(cred.user, { displayName });
-      // onAuthStateChanged will update the signal automatically,
-      // but we can also set it to reflect the displayName immediately:
       this._user.set({ ...cred.user } as User);
     }
     return cred;
@@ -48,12 +48,12 @@ export class AuthService {
 
   /** Send password reset email */
   sendPasswordReset(email: string) {
-    return sendPasswordResetEmail(this.auth, email);
+    return runInInjectionContext(this.injector, () => sendPasswordResetEmail(this.auth, email));
   }
 
   /** Sign out */
   signOut() {
-    return from(signOut(this.auth));
+    return from(runInInjectionContext(this.injector, () => signOut(this.auth)));
   }
 
   /** Convenience getters */

--- a/src/app/features/carousels/carousel.converters.spec.ts
+++ b/src/app/features/carousels/carousel.converters.spec.ts
@@ -1,0 +1,661 @@
+import { Timestamp } from 'firebase/firestore';
+import {
+  Attribution,
+  Carousel,
+  CarouselItem,
+  ImageInfo,
+  ImageVariants,
+} from '../../models/carousel';
+import { carouselConverter, carouselItemConverter } from './carousel.converters';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Build a minimal QueryDocumentSnapshot mock. */
+function makeSnap(id: string, snapshotData: Record<string, unknown>) {
+  return {
+    id,
+    data: (_opts?: unknown) => ({ ...snapshotData }),
+  } as any;
+}
+
+/** A real Timestamp so instanceof checks (if any) still pass. */
+const ts1 = Timestamp.fromDate(new Date('2024-01-15T10:00:00Z'));
+const ts2 = Timestamp.fromDate(new Date('2024-06-20T14:30:00Z'));
+
+// ---------------------------------------------------------------------------
+// carouselItemConverter
+// ---------------------------------------------------------------------------
+
+describe('carouselItemConverter', () => {
+  // -------------------------------------------------------------------------
+  // toFirestore
+  // -------------------------------------------------------------------------
+
+  describe('toFirestore', () => {
+    it('serializes a fully-populated CarouselItem correctly', () => {
+      const item = new CarouselItem();
+      item.position = 1;
+      item.alt = 'A beautiful guitar';
+      item.linkTargetUrl = 'https://example.com/guitars';
+
+      const variants = new ImageVariants();
+      variants.sm = 'https://cdn.example.com/sm.jpg';
+      variants.md = 'https://cdn.example.com/md.jpg';
+      variants.lg = 'https://cdn.example.com/lg.jpg';
+      variants.webpSm = 'https://cdn.example.com/sm.webp';
+      variants.webpMd = 'https://cdn.example.com/md.webp';
+      variants.webpLg = 'https://cdn.example.com/lg.webp';
+
+      const image = new ImageInfo();
+      image.storagePath = 'images/openverse/abc123/original.jpg';
+      image.url = 'https://cdn.example.com/original.jpg';
+      image.width = 1920;
+      image.height = 1080;
+      image.variants = variants;
+      image.blurhash = 'LKO2?U%2Tw=w]~RBVZRi};RPxuwH';
+
+      const attribution = new Attribution();
+      attribution.title = 'Electric Guitar';
+      attribution.creatorName = 'John Doe';
+      attribution.creatorUrl = 'https://example.com/johndoe';
+      attribution.sourceUrl = 'https://openverse.org/image/abc123';
+      attribution.license = 'CC BY 4.0';
+      attribution.licenseUrl = 'https://creativecommons.org/licenses/by/4.0';
+      attribution.changesMade = 'Cropped & resized';
+      attribution.originalFileUrl = 'https://original.example.com/guitar.jpg';
+
+      item.image = image;
+      item.attribution = attribution;
+      item.createdAt = ts1;
+      item.updatedAt = ts2;
+
+      const doc = carouselItemConverter.toFirestore(item);
+
+      expect(doc['position']).toBe(1);
+      expect(doc['alt']).toBe('A beautiful guitar');
+      expect(doc['linkTargetUrl']).toBe('https://example.com/guitars');
+
+      expect(doc['image']).toEqual({
+        storagePath: 'images/openverse/abc123/original.jpg',
+        url: 'https://cdn.example.com/original.jpg',
+        width: 1920,
+        height: 1080,
+        variants: {
+          sm: 'https://cdn.example.com/sm.jpg',
+          md: 'https://cdn.example.com/md.jpg',
+          lg: 'https://cdn.example.com/lg.jpg',
+          webpSm: 'https://cdn.example.com/sm.webp',
+          webpMd: 'https://cdn.example.com/md.webp',
+          webpLg: 'https://cdn.example.com/lg.webp',
+        },
+        blurhash: 'LKO2?U%2Tw=w]~RBVZRi};RPxuwH',
+      });
+
+      expect(doc['attribution']).toEqual({
+        title: 'Electric Guitar',
+        creatorName: 'John Doe',
+        creatorUrl: 'https://example.com/johndoe',
+        sourceName: 'Openverse',
+        sourceUrl: 'https://openverse.org/image/abc123',
+        license: 'CC BY 4.0',
+        licenseUrl: 'https://creativecommons.org/licenses/by/4.0',
+        changesMade: 'Cropped & resized',
+        originalFileUrl: 'https://original.example.com/guitar.jpg',
+      });
+
+      expect(doc['createdAt']).toBe(ts1);
+      expect(doc['updatedAt']).toBe(ts2);
+    });
+
+    it('maps all optional fields to null when they are undefined', () => {
+      const item = new CarouselItem();
+      item.position = 0;
+      item.alt = 'Minimal item';
+      // linkTargetUrl omitted → null
+
+      const image = new ImageInfo();
+      image.url = 'https://cdn.example.com/fallback.jpg';
+      // storagePath, width, height, variants, blurhash all omitted → null
+
+      const attribution = new Attribution();
+      attribution.title = 'Minimal Photo';
+      attribution.creatorName = 'Jane Smith';
+      // creatorUrl omitted → null
+      attribution.sourceUrl = 'https://openverse.org/image/xyz';
+      attribution.license = 'CC BY-SA 4.0';
+      attribution.licenseUrl = 'https://creativecommons.org/licenses/by-sa/4.0';
+      // changesMade omitted → null
+      // originalFileUrl omitted → null
+
+      item.image = image;
+      item.attribution = attribution;
+      // createdAt, updatedAt omitted → null
+
+      const doc = carouselItemConverter.toFirestore(item);
+
+      expect(doc['linkTargetUrl']).toBeNull();
+
+      expect(doc['image']['storagePath']).toBeNull();
+      expect(doc['image']['width']).toBeNull();
+      expect(doc['image']['height']).toBeNull();
+      expect(doc['image']['variants']).toBeNull();
+      expect(doc['image']['blurhash']).toBeNull();
+
+      expect(doc['attribution']['creatorUrl']).toBeNull();
+      expect(doc['attribution']['changesMade']).toBeNull();
+      expect(doc['attribution']['originalFileUrl']).toBeNull();
+
+      expect(doc['createdAt']).toBeNull();
+      expect(doc['updatedAt']).toBeNull();
+    });
+
+    it('serializes image.variants with some variant URLs undefined → null', () => {
+      // Exercise the per-variant ?? null branches inside the variants object.
+      const item = new CarouselItem();
+      item.position = 2;
+      item.alt = 'Partial variants';
+
+      const variants = new ImageVariants();
+      variants.sm = 'https://cdn.example.com/sm.jpg';
+      // md, lg, webpSm, webpMd, webpLg all undefined → null
+
+      const image = new ImageInfo();
+      image.url = 'https://cdn.example.com/fallback.jpg';
+      image.variants = variants;
+
+      const attribution = new Attribution();
+      attribution.title = 'Photo';
+      attribution.creatorName = 'Author';
+      attribution.sourceUrl = 'https://openverse.org/image/1';
+      attribution.license = 'CC BY 4.0';
+      attribution.licenseUrl = 'https://creativecommons.org/licenses/by/4.0';
+
+      item.image = image;
+      item.attribution = attribution;
+
+      const doc = carouselItemConverter.toFirestore(item);
+
+      expect(doc['image']['variants']).toEqual({
+        sm: 'https://cdn.example.com/sm.jpg',
+        md: null,
+        lg: null,
+        webpSm: null,
+        webpMd: null,
+        webpLg: null,
+      });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // fromFirestore
+  // -------------------------------------------------------------------------
+
+  describe('fromFirestore', () => {
+    it('reconstructs a fully-populated CarouselItem from snapshot data', () => {
+      const snapshotData = {
+        position: 3,
+        alt: 'Acoustic guitar on stage',
+        linkTargetUrl: 'https://example.com/stage',
+        image: {
+          storagePath: 'images/openverse/stage/original.jpg',
+          url: 'https://cdn.example.com/stage.jpg',
+          width: 1280,
+          height: 720,
+          variants: {
+            sm: 'https://cdn.example.com/stage-sm.jpg',
+            md: 'https://cdn.example.com/stage-md.jpg',
+            lg: 'https://cdn.example.com/stage-lg.jpg',
+            webpSm: 'https://cdn.example.com/stage-sm.webp',
+            webpMd: 'https://cdn.example.com/stage-md.webp',
+            webpLg: 'https://cdn.example.com/stage-lg.webp',
+          },
+          blurhash: 'LHBzxst7IUM{~qj[j[az',
+        },
+        attribution: {
+          title: 'On Stage',
+          creatorName: 'Alice',
+          creatorUrl: 'https://example.com/alice',
+          sourceName: 'Openverse',
+          sourceUrl: 'https://openverse.org/image/stage',
+          license: 'CC BY 2.0',
+          licenseUrl: 'https://creativecommons.org/licenses/by/2.0',
+          changesMade: 'Cropped',
+          originalFileUrl: 'https://original.example.com/stage.jpg',
+        },
+        createdAt: ts1,
+        updatedAt: ts2,
+      };
+
+      const snap = makeSnap('item-abc', snapshotData);
+      const result = carouselItemConverter.fromFirestore(snap, {});
+
+      expect(result).toBeInstanceOf(CarouselItem);
+      expect(result.id).toBe('item-abc');
+      expect(result.position).toBe(3);
+      expect(result.alt).toBe('Acoustic guitar on stage');
+      expect(result.linkTargetUrl).toBe('https://example.com/stage');
+
+      expect(result.image).toBeInstanceOf(ImageInfo);
+      expect(result.image.storagePath).toBe('images/openverse/stage/original.jpg');
+      expect(result.image.url).toBe('https://cdn.example.com/stage.jpg');
+      expect(result.image.width).toBe(1280);
+      expect(result.image.height).toBe(720);
+      expect(result.image.blurhash).toBe('LHBzxst7IUM{~qj[j[az');
+
+      expect(result.image.variants).toBeInstanceOf(ImageVariants);
+      expect(result.image.variants!.sm).toBe('https://cdn.example.com/stage-sm.jpg');
+      expect(result.image.variants!.md).toBe('https://cdn.example.com/stage-md.jpg');
+      expect(result.image.variants!.lg).toBe('https://cdn.example.com/stage-lg.jpg');
+      expect(result.image.variants!.webpSm).toBe('https://cdn.example.com/stage-sm.webp');
+      expect(result.image.variants!.webpMd).toBe('https://cdn.example.com/stage-md.webp');
+      expect(result.image.variants!.webpLg).toBe('https://cdn.example.com/stage-lg.webp');
+
+      expect(result.attribution).toBeInstanceOf(Attribution);
+      expect(result.attribution.title).toBe('On Stage');
+      expect(result.attribution.creatorName).toBe('Alice');
+      expect(result.attribution.creatorUrl).toBe('https://example.com/alice');
+      expect(result.attribution.sourceName).toBe('Openverse');
+      expect(result.attribution.sourceUrl).toBe('https://openverse.org/image/stage');
+      expect(result.attribution.license).toBe('CC BY 2.0');
+      expect(result.attribution.licenseUrl).toBe('https://creativecommons.org/licenses/by/2.0');
+      expect(result.attribution.changesMade).toBe('Cropped');
+      expect(result.attribution.originalFileUrl).toBe('https://original.example.com/stage.jpg');
+
+      expect(result.createdAt).toBe(ts1);
+      expect(result.updatedAt).toBe(ts2);
+    });
+
+    it('falls back to undefined for all optional fields when they are absent from data', () => {
+      const snapshotData = {
+        position: 0,
+        alt: 'Sparse item',
+        // linkTargetUrl absent → undefined
+        image: {
+          // storagePath absent → undefined
+          url: 'https://cdn.example.com/fallback.jpg',
+          // width, height, variants, blurhash absent → undefined
+        },
+        attribution: {
+          title: 'Minimal',
+          creatorName: 'Bob',
+          // creatorUrl absent → undefined
+          sourceUrl: 'https://openverse.org/image/minimal',
+          license: 'CC BY 4.0',
+          licenseUrl: 'https://creativecommons.org/licenses/by/4.0',
+          // changesMade, originalFileUrl absent → undefined
+        },
+        // createdAt, updatedAt absent → undefined
+      };
+
+      const snap = makeSnap('item-sparse', snapshotData);
+      const result = carouselItemConverter.fromFirestore(snap, {});
+
+      expect(result.linkTargetUrl).toBeUndefined();
+      expect(result.image.storagePath).toBeUndefined();
+      expect(result.image.width).toBeUndefined();
+      expect(result.image.height).toBeUndefined();
+      expect(result.image.variants).toBeUndefined();
+      expect(result.image.blurhash).toBeUndefined();
+      expect(result.attribution.creatorUrl).toBeUndefined();
+      expect(result.attribution.changesMade).toBeUndefined();
+      expect(result.attribution.originalFileUrl).toBeUndefined();
+      expect(result.createdAt).toBeUndefined();
+      expect(result.updatedAt).toBeUndefined();
+    });
+
+    it('falls back to undefined for optional fields when they are explicitly null in Firestore', () => {
+      // Firestore stores null for optional fields that were absent at write time.
+      // The ?? undefined branch should convert null → undefined.
+      const snapshotData = {
+        position: 1,
+        alt: 'Null fields item',
+        linkTargetUrl: null,
+        image: {
+          storagePath: null,
+          url: 'https://cdn.example.com/img.jpg',
+          width: null,
+          height: null,
+          variants: null,
+          blurhash: null,
+        },
+        attribution: {
+          title: 'Photo',
+          creatorName: 'Carol',
+          creatorUrl: null,
+          sourceUrl: 'https://openverse.org/image/n',
+          license: 'CC BY-SA 4.0',
+          licenseUrl: 'https://creativecommons.org/licenses/by-sa/4.0',
+          changesMade: null,
+          originalFileUrl: null,
+        },
+        createdAt: null,
+        updatedAt: null,
+      };
+
+      const snap = makeSnap('item-nulls', snapshotData);
+      const result = carouselItemConverter.fromFirestore(snap, {});
+
+      expect(result.linkTargetUrl).toBeUndefined();
+      expect(result.image.storagePath).toBeUndefined();
+      expect(result.image.width).toBeUndefined();
+      expect(result.image.height).toBeUndefined();
+      expect(result.image.variants).toBeUndefined();
+      expect(result.image.blurhash).toBeUndefined();
+      expect(result.attribution.creatorUrl).toBeUndefined();
+      expect(result.attribution.changesMade).toBeUndefined();
+      expect(result.attribution.originalFileUrl).toBeUndefined();
+      expect(result.createdAt).toBeUndefined();
+      expect(result.updatedAt).toBeUndefined();
+    });
+
+    it('falls back to empty strings when attribution fields are absent', () => {
+      const snapshotData = {
+        position: 2,
+        alt: 'Empty strings',
+        image: { url: 'https://cdn.example.com/x.jpg' },
+        // attribution key itself absent → all ?. chains resolve to undefined → ''
+      };
+
+      const snap = makeSnap('item-no-attr', snapshotData);
+      const result = carouselItemConverter.fromFirestore(snap, {});
+
+      expect(result.attribution.title).toBe('');
+      expect(result.attribution.creatorName).toBe('');
+      expect(result.attribution.sourceUrl).toBe('');
+      expect(result.attribution.license).toBe('');
+      expect(result.attribution.licenseUrl).toBe('');
+    });
+
+    it('falls back to empty string for image.url when image key is absent', () => {
+      const snapshotData = {
+        position: 5,
+        alt: 'No image key',
+        // image key entirely absent → url defaults to ''
+      };
+
+      const snap = makeSnap('item-no-image', snapshotData);
+      const result = carouselItemConverter.fromFirestore(snap, {});
+
+      expect(result.image.url).toBe('');
+    });
+
+    it('populates only the present variant URLs and leaves the rest undefined', () => {
+      const snapshotData = {
+        position: 4,
+        alt: 'Partial variants item',
+        image: {
+          url: 'https://cdn.example.com/partial.jpg',
+          variants: {
+            sm: 'https://cdn.example.com/partial-sm.jpg',
+            md: null,   // null → undefined
+            lg: null,   // null → undefined
+            webpSm: 'https://cdn.example.com/partial-sm.webp',
+            webpMd: null,
+            webpLg: null,
+          },
+        },
+        attribution: {
+          title: 'Partial',
+          creatorName: 'Dave',
+          sourceUrl: 'https://openverse.org/image/partial',
+          license: 'CC BY 4.0',
+          licenseUrl: 'https://creativecommons.org/licenses/by/4.0',
+        },
+      };
+
+      const snap = makeSnap('item-partial', snapshotData);
+      const result = carouselItemConverter.fromFirestore(snap, {});
+
+      expect(result.image.variants).toBeInstanceOf(ImageVariants);
+      expect(result.image.variants!.sm).toBe('https://cdn.example.com/partial-sm.jpg');
+      expect(result.image.variants!.md).toBeUndefined();
+      expect(result.image.variants!.lg).toBeUndefined();
+      expect(result.image.variants!.webpSm).toBe('https://cdn.example.com/partial-sm.webp');
+      expect(result.image.variants!.webpMd).toBeUndefined();
+      expect(result.image.variants!.webpLg).toBeUndefined();
+    });
+
+    it('passes SnapshotOptions to snap.data()', () => {
+      const dataFn = jest.fn().mockReturnValue({
+        position: 0,
+        alt: 'opts test',
+        image: { url: 'https://cdn.example.com/opts.jpg' },
+      });
+      const snap = { id: 'opts-snap', data: dataFn } as any;
+      const opts = { serverTimestamps: 'estimate' as const };
+
+      carouselItemConverter.fromFirestore(snap, opts);
+
+      expect(dataFn).toHaveBeenCalledWith(opts);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// carouselConverter
+// ---------------------------------------------------------------------------
+
+describe('carouselConverter', () => {
+  // -------------------------------------------------------------------------
+  // toFirestore
+  // -------------------------------------------------------------------------
+
+  describe('toFirestore', () => {
+    it('serializes a fully-populated Carousel correctly', () => {
+      const carousel = new Carousel();
+      carousel.name = 'Dashboard Hero';
+      carousel.slug = 'dashboard-hero';
+      carousel.rotateMs = 7000;
+      carousel.aspectRatio = '4/3';
+      carousel.isActive = true;
+      carousel.createdAt = ts1;
+      carousel.updatedAt = ts2;
+
+      const doc = carouselConverter.toFirestore(carousel);
+
+      expect(doc).toEqual({
+        name: 'Dashboard Hero',
+        slug: 'dashboard-hero',
+        rotateMs: 7000,
+        aspectRatio: '4/3',
+        isActive: true,
+        createdAt: ts1,
+        updatedAt: ts2,
+      });
+    });
+
+    it('maps createdAt and updatedAt to null when they are undefined', () => {
+      const carousel = new Carousel();
+      carousel.name = 'Featured Guitars';
+      carousel.slug = 'featured-guitars';
+      // createdAt, updatedAt omitted → null
+
+      const doc = carouselConverter.toFirestore(carousel);
+
+      expect(doc['createdAt']).toBeNull();
+      expect(doc['updatedAt']).toBeNull();
+    });
+
+    it('serializes isActive=false correctly', () => {
+      const carousel = new Carousel();
+      carousel.name = 'Inactive Carousel';
+      carousel.slug = 'inactive';
+      carousel.isActive = false;
+
+      const doc = carouselConverter.toFirestore(carousel);
+
+      expect(doc['isActive']).toBe(false);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // fromFirestore
+  // -------------------------------------------------------------------------
+
+  describe('fromFirestore', () => {
+    it('reconstructs a fully-populated Carousel from snapshot data', () => {
+      const snapshotData = {
+        name: 'Homepage Banner',
+        slug: 'homepage-banner',
+        rotateMs: 8000,
+        aspectRatio: '21/9',
+        isActive: false,
+        createdAt: ts1,
+        updatedAt: ts2,
+      };
+
+      const snap = makeSnap('carousel-xyz', snapshotData);
+      const result = carouselConverter.fromFirestore(snap, {});
+
+      expect(result).toBeInstanceOf(Carousel);
+      expect(result.id).toBe('carousel-xyz');
+      expect(result.name).toBe('Homepage Banner');
+      expect(result.slug).toBe('homepage-banner');
+      expect(result.rotateMs).toBe(8000);
+      expect(result.aspectRatio).toBe('21/9');
+      expect(result.isActive).toBe(false);
+      expect(result.createdAt).toBe(ts1);
+      expect(result.updatedAt).toBe(ts2);
+    });
+
+    it('defaults rotateMs to 5000 when absent from data', () => {
+      const snapshotData = {
+        name: 'Default Rotate',
+        slug: 'default-rotate',
+        aspectRatio: '16/9',
+        isActive: true,
+      };
+
+      const snap = makeSnap('carousel-rotate', snapshotData);
+      const result = carouselConverter.fromFirestore(snap, {});
+
+      expect(result.rotateMs).toBe(5000);
+    });
+
+    it('defaults rotateMs to 5000 when explicitly null in Firestore', () => {
+      const snapshotData = {
+        name: 'Null Rotate',
+        slug: 'null-rotate',
+        rotateMs: null,
+        aspectRatio: '16/9',
+        isActive: true,
+      };
+
+      const snap = makeSnap('carousel-null-rotate', snapshotData);
+      const result = carouselConverter.fromFirestore(snap, {});
+
+      expect(result.rotateMs).toBe(5000);
+    });
+
+    it('defaults aspectRatio to "16/9" when absent from data', () => {
+      const snapshotData = {
+        name: 'Default Ratio',
+        slug: 'default-ratio',
+        rotateMs: 5000,
+        isActive: true,
+      };
+
+      const snap = makeSnap('carousel-ratio', snapshotData);
+      const result = carouselConverter.fromFirestore(snap, {});
+
+      expect(result.aspectRatio).toBe('16/9');
+    });
+
+    it('defaults aspectRatio to "16/9" when explicitly null in Firestore', () => {
+      const snapshotData = {
+        name: 'Null Ratio',
+        slug: 'null-ratio',
+        rotateMs: 3000,
+        aspectRatio: null,
+        isActive: true,
+      };
+
+      const snap = makeSnap('carousel-null-ratio', snapshotData);
+      const result = carouselConverter.fromFirestore(snap, {});
+
+      expect(result.aspectRatio).toBe('16/9');
+    });
+
+    it('defaults isActive to true when absent from data', () => {
+      const snapshotData = {
+        name: 'Default Active',
+        slug: 'default-active',
+        rotateMs: 5000,
+        aspectRatio: '16/9',
+      };
+
+      const snap = makeSnap('carousel-active', snapshotData);
+      const result = carouselConverter.fromFirestore(snap, {});
+
+      expect(result.isActive).toBe(true);
+    });
+
+    it('defaults isActive to true when explicitly null in Firestore', () => {
+      const snapshotData = {
+        name: 'Null Active',
+        slug: 'null-active',
+        rotateMs: 5000,
+        aspectRatio: '16/9',
+        isActive: null,
+      };
+
+      const snap = makeSnap('carousel-null-active', snapshotData);
+      const result = carouselConverter.fromFirestore(snap, {});
+
+      expect(result.isActive).toBe(true);
+    });
+
+    it('falls back to undefined for createdAt and updatedAt when absent', () => {
+      const snapshotData = {
+        name: 'No Timestamps',
+        slug: 'no-timestamps',
+        rotateMs: 5000,
+        aspectRatio: '16/9',
+        isActive: true,
+        // createdAt, updatedAt absent → undefined
+      };
+
+      const snap = makeSnap('carousel-no-ts', snapshotData);
+      const result = carouselConverter.fromFirestore(snap, {});
+
+      expect(result.createdAt).toBeUndefined();
+      expect(result.updatedAt).toBeUndefined();
+    });
+
+    it('falls back to undefined for createdAt and updatedAt when explicitly null', () => {
+      const snapshotData = {
+        name: 'Null Timestamps',
+        slug: 'null-timestamps',
+        rotateMs: 5000,
+        aspectRatio: '16/9',
+        isActive: true,
+        createdAt: null,
+        updatedAt: null,
+      };
+
+      const snap = makeSnap('carousel-null-ts', snapshotData);
+      const result = carouselConverter.fromFirestore(snap, {});
+
+      expect(result.createdAt).toBeUndefined();
+      expect(result.updatedAt).toBeUndefined();
+    });
+
+    it('passes SnapshotOptions to snap.data()', () => {
+      const dataFn = jest.fn().mockReturnValue({
+        name: 'Opts Carousel',
+        slug: 'opts-carousel',
+        rotateMs: 5000,
+        aspectRatio: '16/9',
+        isActive: true,
+      });
+      const snap = { id: 'carousel-opts', data: dataFn } as any;
+      const opts = { serverTimestamps: 'none' as const };
+
+      carouselConverter.fromFirestore(snap, opts);
+
+      expect(dataFn).toHaveBeenCalledWith(opts);
+    });
+  });
+});

--- a/src/app/features/dashboard/dashboard.component.html
+++ b/src/app/features/dashboard/dashboard.component.html
@@ -90,7 +90,7 @@
         @for (session of data().recentSessions; track session.id; let last = $last) {
           <li [class.border-b]="!last" class="border-gj-border">
             <a
-              [routerLink]="['/app/sessions', session.id]"
+              [routerLink]="['/app/sessionDetail', session.id]"
               class="flex items-center gap-4 px-5 py-3.5 hover:bg-gj-background transition-colors duration-150"
             >
               <!-- Icon -->

--- a/src/app/features/session/display-single-session/display-session.component.html
+++ b/src/app/features/session/display-single-session/display-session.component.html
@@ -1,9 +1,10 @@
 <!-- display-session.component.html -->
+@let s = session();
 @if (loading()) {
   <p>Loading…</p>
 } @else if (hasError()) {
   <p class="text-red-600">Could not load the session.</p>
-} @else if (session()) {
+} @else if (s) {
   <div class="flex flex-col gap-4">
     <p-card>
       <ng-template pTemplate="header">
@@ -14,27 +15,30 @@
         <!-- Portrait mode: headings left, data right -->
         <dl class="grid grid-cols-1 md:grid-cols-[240px,1fr] gap-x-6 gap-y-3">
           <dt class="text-sm font-medium text-neutral-500">Date</dt>
-          <dd class="text-neutral-900">{{ session().date.toDate() | date:'MMM d, y'}}</dd>
+          <dd class="text-neutral-900">{{ s.date.toDate() | date:'MMM d, y'}}</dd>
 
           <dt class="text-sm font-medium text-neutral-500">Practice Time</dt>
-          <dd class="text-neutral-900">{{ session().practiceTime }}</dd>
+          <dd class="text-neutral-900">{{ s.practiceTime }}</dd>
 
           <dt class="text-sm font-medium text-neutral-500">What You Practiced</dt>
-          <dd class="text-neutral-900 whitespace-pre-line">{{ session().whatToPractice }}</dd>
+          <dd class="text-neutral-900 whitespace-pre-line">{{ s.whatToPractice }}</dd>
 
           <dt class="text-sm font-medium text-neutral-500">Session Intent</dt>
-          <dd class="text-neutral-900 whitespace-pre-line">{{ session().sessionIntent }}</dd>
+          <dd class="text-neutral-900 whitespace-pre-line">{{ s.sessionIntent }}</dd>
 
           <dt class="text-sm font-medium text-neutral-500">Reflection</dt>
-          <dd class="text-neutral-900 whitespace-pre-line">{{ session().postPracticeReflection }}</dd>
+          <dd class="text-neutral-900 whitespace-pre-line">{{ s.postPracticeReflection }}</dd>
 
           <dt class="text-sm font-medium text-neutral-500">Goal for next time</dt>
-          <dd class="text-neutral-900 whitespace-pre-line">{{ session().goalForNextTime }}</dd>
+          <dd class="text-neutral-900 whitespace-pre-line">{{ s.goalForNextTime }}</dd>
         </dl>
       </ng-template>
 
       <ng-template pTemplate="footer">
-        <button pButton type="button" data-testid="back" (click)="returnToTable()" label="Back" name="back"></button>
+        <div class="flex gap-2">
+          <button pButton type="button" data-testid="back" (click)="returnToTable()" label="Back" name="back"></button>
+          <button pButton type="button" data-testid="dashboard" (click)="goToDashboard()" label="Dashboard" name="dashboard"></button>
+        </div>
       </ng-template>
     </p-card>
   </div>

--- a/src/app/features/session/display-single-session/display-session.component.spec.ts
+++ b/src/app/features/session/display-single-session/display-session.component.spec.ts
@@ -16,7 +16,7 @@ describe('DisplaySessionComponent (standalone)', () => {
   // Session service mock with multiple possible method names to be robust
   const makeSession = (over: Partial<Session> = {}): Session => ({
     id: '123',
-    date: '2025-08-01',
+    date: { toDate: () => new Date('2025-08-01'), seconds: 0, nanoseconds: 0 } as any,
     practiceTime: 35,
     whatToPractice: 'Pentatonics',
     sessionIntent: 'Speed & accuracy',
@@ -31,6 +31,7 @@ describe('DisplaySessionComponent (standalone)', () => {
     getSessionById: jest.fn((id: string) => get$ ?? of(makeSession())),
     getById:         jest.fn((id: string) => get$ ?? of(makeSession())),
     findOne:         jest.fn((id: string) => get$ ?? of(makeSession())),
+    get$:            jest.fn((id: string) => get$ ?? of(makeSession())),
   };
 
   async function setup() {
@@ -107,6 +108,42 @@ describe('DisplaySessionComponent (standalone)', () => {
     expect(modes).toBeTruthy;
     const time = screen.findAllByDisplayValue('50 min');
     expect(time).toBeTruthy;
+  });
+
+  it('hasError is false before an id is emitted (sessionId is null)', async () => {
+    await setup();
+    // No id emitted yet — sessionId() is null, so hasError short-circuits to false
+    fixture.detectChanges();
+    expect(fixture.componentInstance.hasError()).toBe(false);
+  });
+
+  it('hasError is false when session loads successfully', async () => {
+    await setup();
+    emitId('abc');
+    get$.next(makeSession({ id: 'abc' }));
+    get$.complete();
+    fixture.detectChanges();
+    expect(fixture.componentInstance.hasError()).toBe(false);
+  });
+
+  it('hasError is true when the service errors after an id is emitted', async () => {
+    await setup();
+    emitId('999');
+    get$.error(new Error('boom'));
+    fixture.detectChanges();
+    expect(fixture.componentInstance.hasError()).toBe(true);
+  });
+
+  it('goToDashboard navigates to /app/dashboard', () => {
+    const navSpy = jest.spyOn(router, 'navigate').mockResolvedValue(true as any);
+    fixture.componentInstance.goToDashboard();
+    expect(navSpy).toHaveBeenCalledWith(['/app', 'dashboard']);
+  });
+
+  it('returnToTable navigates to /app/sessions', () => {
+    const navSpy = jest.spyOn(router, 'navigate').mockResolvedValue(true as any);
+    fixture.componentInstance.returnToTable();
+    expect(navSpy).toHaveBeenCalledWith(['/app', 'sessions']);
   });
 
   //TODO: fix this test

--- a/src/app/features/session/display-single-session/display-session.component.ts
+++ b/src/app/features/session/display-single-session/display-session.component.ts
@@ -45,4 +45,8 @@ export class DisplaySessionComponent {
   returnToTable(): void {
     this.router.navigate(['/app','sessions']);
   }
+
+  goToDashboard(): void {
+    this.router.navigate(['/app', 'dashboard']);
+  }
 }

--- a/src/app/features/session/session-resource-picker/session-resource-picker.component.html
+++ b/src/app/features/session/session-resource-picker/session-resource-picker.component.html
@@ -1,57 +1,78 @@
 <div class="space-y-4">
 
-  <!-- ── YOUR LIBRARY ─────────────────────────────────────── -->
+  <!-- ── SEARCH EXISTING ──────────────────────────────────── -->
   <div>
-    <p class="text-xs font-medium text-neutral-500 uppercase tracking-wide mb-2">Your Library</p>
+    <p class="text-xs font-medium text-neutral-500 uppercase tracking-wide mb-2">Search Existing</p>
 
     @if (libraryLoading()) {
-      <div class="space-y-2">
-        @for (_ of [1, 2, 3]; track $index) {
-          <p-skeleton height="40px" />
-        }
-      </div>
-    } @else if (allResources().length === 0) {
-      <p-message severity="info">No saved resources yet — add a YouTube tutorial, tab, or PDF below and it'll be waiting here next time.</p-message>
+      <p-skeleton height="40px" />
     } @else {
-      <!-- Filters -->
-      <div class="space-y-2 mb-2">
-        <input
-          type="text"
-          pInputText
-          placeholder="Search by name…"
-          [(ngModel)]="labelFilter"
-          class="w-full"
-        />
-        <p-autocomplete
-          [(ngModel)]="tagFilter"
-          [multiple]="true"
-          [dropdown]="false"
-          [suggestions]="[]"
-          placeholder="Filter by tag…"
-          class="w-full"
-        />
-      </div>
+      <input
+        type="text"
+        pInputText
+        placeholder="Search by name, URL or tag…"
+        [(ngModel)]="searchQuery"
+        class="w-full"
+      />
 
-      @if (filteredResources.length === 0) {
-        <p-message severity="warn">No resources match your filters.</p-message>
-      } @else {
-        <p-listbox
-          [options]="filteredResources"
-          optionLabel="label"
-          [style]="{ 'width': '100%' }"
-          (onChange)="onLibrarySelect($event.value)"
-        />
+      @if (searchQuery.length >= 3) {
+        @if (searchResults.length === 0) {
+          <p-message severity="info" class="mt-2 block">No matching resources found.</p-message>
+        } @else {
+          <p-table [value]="searchResults" class="mt-2" [tableStyle]="{ 'min-width': '100%' }">
+            <ng-template pTemplate="header">
+              <tr>
+                <th>Label</th>
+                <th>Type</th>
+                <th></th>
+              </tr>
+            </ng-template>
+            <ng-template pTemplate="body" let-resource>
+              <tr>
+                <td class="text-sm">{{ resource.label }}</td>
+                <td class="text-sm text-neutral-500">{{ resource.type }}</td>
+                <td class="text-right">
+                  <p-button
+                    label="Add"
+                    type="button"
+                    [text]="true"
+                    size="small"
+                    (click)="onLibrarySelect(resource)"
+                  />
+                </td>
+              </tr>
+            </ng-template>
+          </p-table>
+        }
       }
     }
   </div>
 
-  <hr class="border-t border-neutral-200">
-
   <!-- ── ADD NEW ───────────────────────────────────────────── -->
   <div>
-    <p class="text-xs font-medium text-neutral-500 uppercase tracking-wide mb-2">Add New</p>
-    <div class="space-y-3">
+    <p-button
+      label="Add New Resource"
+      icon="pi pi-plus"
+      type="button"
+      (click)="showAddDialog = true"
+    />
+  </div>
 
+</div>
+
+<!-- ── ADD NEW DIALOG ────────────────────────────────────── -->
+<p-dialog
+  header="Add New Resource"
+  [(visible)]="showAddDialog"
+  [modal]="true"
+  [style]="{ width: '480px' }"
+  [breakpoints]="{ '640px': '95vw' }"
+  [draggable]="false"
+>
+  <div class="space-y-4 py-2">
+
+    <div>
+      <label class="block text-sm font-medium text-neutral-800 mb-1">Type</label>
       <p-select
         [(ngModel)]="newType"
         [options]="typeOptions"
@@ -60,51 +81,68 @@
         class="w-full"
         (onChange)="onTypeChange()"
       />
+    </div>
 
+    <div>
+      <label class="block text-sm font-medium text-neutral-800 mb-1">URL</label>
       <input
         type="text"
         pInputText
-        placeholder="URL"
+        placeholder="https://..."
         [(ngModel)]="newUrl"
         class="w-full"
         (blur)="onUrlBlur()"
       />
+    </div>
 
-      @if (oEmbedLoading()) {
-        <p-skeleton height="112px" />
-      } @else if (oEmbedThumbnail()) {
-        <img
-          [src]="oEmbedThumbnail()"
-          alt="Video thumbnail"
-          class="w-full object-cover rounded-xl"
-        />
-      }
+    @if (oEmbedLoading()) {
+      <p-skeleton height="112px" />
+    } @else if (oEmbedThumbnail()) {
+      <img
+        [src]="oEmbedThumbnail()"
+        alt="Video thumbnail"
+        class="w-full object-cover rounded-xl"
+      />
+    }
 
+    <div>
+      <label class="block text-sm font-medium text-neutral-800 mb-1">Label</label>
       <input
         type="text"
         pInputText
-        placeholder="Label"
+        placeholder="Descriptive name"
         [(ngModel)]="newLabel"
         class="w-full"
       />
+    </div>
 
+    <div>
+      <label class="block text-sm font-medium text-neutral-800 mb-1">Tags</label>
       <p-autocomplete
         [ngModel]="newTags"
         (ngModelChange)="newTags = $event"
         [multiple]="true"
         [dropdown]="false"
         [suggestions]="tagSuggestions"
-        placeholder="Tags (press Enter to add)"
+        placeholder="Press Enter to add"
         class="w-full"
       />
-
-      <p-button
-        label="Add"
-        type="button"
-        [disabled]="!canAdd"
-        (click)="onAdd()"
-      />
     </div>
+
   </div>
 
-</div>
+  <ng-template pTemplate="footer">
+    <p-button
+      label="Cancel"
+      type="button"
+      [text]="true"
+      (click)="showAddDialog = false"
+    />
+    <p-button
+      label="Add Resource"
+      type="button"
+      [disabled]="!canAdd"
+      (click)="onAdd()"
+    />
+  </ng-template>
+</p-dialog>

--- a/src/app/features/session/session-resource-picker/session-resource-picker.component.spec.ts
+++ b/src/app/features/session/session-resource-picker/session-resource-picker.component.spec.ts
@@ -1,9 +1,18 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
-import { of } from 'rxjs';
+import { Subject, of } from 'rxjs';
 import { SessionResourcePickerComponent } from './session-resource-picker.component';
 import { ResourceService } from '../../../services/resource.service';
 import { Resource } from '../../../models/resource';
+import * as youtube from '../../../utils/youtube';
+
+jest.mock('../../../utils/youtube', () => {
+  const actual = jest.requireActual('../../../utils/youtube');
+  return {
+    ...actual,
+    fetchYouTubeOEmbed: jest.fn(),
+  };
+});
 
 const mockResource = (over: Partial<Resource> = {}): Resource => ({
   id: 'res-1',
@@ -41,6 +50,8 @@ describe('SessionResourcePickerComponent', () => {
     fixture.detectChanges();
   });
 
+  // ── Creation ────────────────────────────────────────────────
+
   it('should create', () => {
     expect(component).toBeTruthy();
   });
@@ -48,6 +59,8 @@ describe('SessionResourcePickerComponent', () => {
   it('sets libraryLoading to false after getResources emits', () => {
     expect(component.libraryLoading()).toBe(false);
   });
+
+  // ── canAdd ──────────────────────────────────────────────────
 
   it('canAdd is false when url is empty', () => {
     component.newUrl = '';
@@ -58,6 +71,13 @@ describe('SessionResourcePickerComponent', () => {
   it('canAdd is false when label is empty', () => {
     component.newUrl = 'https://www.youtube.com/watch?v=dQw4w9WgXcQ';
     component.newLabel = '';
+    expect(component.canAdd).toBe(false);
+  });
+
+  it('canAdd is false when URL has non-http protocol', () => {
+    component.newType = 'pdf';
+    component.newUrl = 'ftp://example.com/tab.pdf';
+    component.newLabel = 'My PDF';
     expect(component.canAdd).toBe(false);
   });
 
@@ -80,6 +100,17 @@ describe('SessionResourcePickerComponent', () => {
     component.newUrl = 'https://example.com/tab.pdf';
     component.newLabel = 'Tab PDF';
     expect(component.canAdd).toBe(true);
+  });
+
+  // ── onAdd ───────────────────────────────────────────────────
+
+  it('onAdd does nothing when canAdd is false', () => {
+    component.newUrl = '';
+    component.newLabel = '';
+    const emitted: any[] = [];
+    component.resourceAdded.subscribe(v => emitted.push(v));
+    component.onAdd();
+    expect(emitted).toHaveLength(0);
   });
 
   it('emits resourceAdded with correct shape when onAdd is called', () => {
@@ -117,6 +148,20 @@ describe('SessionResourcePickerComponent', () => {
     expect(component.newTags).toEqual([]);
   });
 
+  it('closes the Add New dialog after onAdd', () => {
+    component.showAddDialog = true;
+    component.newType = 'pdf';
+    component.newUrl = 'https://example.com/tab.pdf';
+    component.newLabel = 'My Tab';
+
+    component.resourceAdded.subscribe(() => {});
+    component.onAdd();
+
+    expect(component.showAddDialog).toBe(false);
+  });
+
+  // ── onLibrarySelect ─────────────────────────────────────────
+
   it('emits resourceAdded with resourceId when onLibrarySelect is called', () => {
     const resource = mockResource({ id: 'lib-id-1', type: 'youtube', tags: ['jazz'] });
     const emitted: any[] = [];
@@ -130,6 +175,14 @@ describe('SessionResourcePickerComponent', () => {
     expect(emitted[0].type).toBe('youtube');
   });
 
+  it('onLibrarySelect defaults tags to [] when resource.tags is undefined', () => {
+    const resource = mockResource({ id: 'lib-id-2', tags: undefined });
+    const emitted: any[] = [];
+    component.resourceAdded.subscribe(v => emitted.push(v));
+    component.onLibrarySelect(resource);
+    expect(emitted[0].tags).toEqual([]);
+  });
+
   it('does not emit if onLibrarySelect receives a resource without an id', () => {
     const resource = mockResource({ id: undefined });
     const emitted: any[] = [];
@@ -140,25 +193,209 @@ describe('SessionResourcePickerComponent', () => {
     expect(emitted).toHaveLength(0);
   });
 
-  it('filteredResources filters by label case-insensitively', () => {
-    mockResourceService.getResources.mockReturnValue(
-      of([
-        mockResource({ id: '1', label: 'Blues Scale' }),
-        mockResource({ id: '2', label: 'Jazz Chord' }),
-      ])
-    );
+  // ── searchResults ────────────────────────────────────────────
+
+  describe('searchResults', () => {
+    beforeEach(async () => {
+      mockResourceService.getResources.mockReturnValue(of([
+        mockResource({ id: '1', label: 'Blues Scale Tutorial', url: 'https://yt.com/blues', tags: ['blues', 'scale'] }),
+        mockResource({ id: '2', label: 'Jazz Chord Voicings', url: 'https://yt.com/jazz', tags: ['jazz'] }),
+        mockResource({ id: '3', label: 'Pentatonic Runs', url: 'https://example.com/tab.pdf', tags: ['blues', 'lead'] }),
+      ]));
+
+      fixture = TestBed.createComponent(SessionResourcePickerComponent);
+      component = fixture.componentInstance;
+      fixture.detectChanges();
+    });
+
+    it('returns empty array when searchQuery is fewer than 3 chars', () => {
+      component.searchQuery = 'bl';
+      expect(component.searchResults).toHaveLength(0);
+    });
+
+    it('returns empty array when searchQuery is empty', () => {
+      component.searchQuery = '';
+      expect(component.searchResults).toHaveLength(0);
+    });
+
+    it('filters by label (case-insensitive)', () => {
+      component.searchQuery = 'blues';
+      const ids = component.searchResults.map(r => r.id);
+      expect(ids).toContain('1');
+      expect(ids).not.toContain('2');
+      expect(ids).toContain('3');
+    });
+
+    it('filters by URL', () => {
+      component.searchQuery = 'example.com';
+      const ids = component.searchResults.map(r => r.id);
+      expect(ids).toEqual(['3']);
+    });
+
+    it('filters by tag', () => {
+      component.searchQuery = 'jazz';
+      const ids = component.searchResults.map(r => r.id);
+      expect(ids).toEqual(['2']);
+    });
+
+    it('returns at most 20 results', () => {
+      const manyResources = Array.from({ length: 25 }, (_, i) =>
+        mockResource({ id: `r${i}`, label: `searchable item ${i}` })
+      );
+      mockResourceService.getResources.mockReturnValue(of(manyResources));
+
+      fixture = TestBed.createComponent(SessionResourcePickerComponent);
+      component = fixture.componentInstance;
+      fixture.detectChanges();
+
+      component.searchQuery = 'searchable';
+      expect(component.searchResults.length).toBeLessThanOrEqual(20);
+    });
+
+    it('returns empty array when no resources match', () => {
+      component.searchQuery = 'xyznotfound';
+      expect(component.searchResults).toHaveLength(0);
+    });
+
+    it('handles resources without tags (tags is undefined) without throwing', () => {
+      mockResourceService.getResources.mockReturnValue(of([
+        mockResource({ id: '10', label: 'xyzunique', url: 'https://zt.com/abc', tags: undefined }),
+      ]));
+
+      fixture = TestBed.createComponent(SessionResourcePickerComponent);
+      component = fixture.componentInstance;
+      fixture.detectChanges();
+
+      // 'xyzunique' matches label so resource is found; tags check is not reached here
+      component.searchQuery = 'xyzunique';
+      expect(component.searchResults).toHaveLength(1);
+
+      // Now search something that doesn't match label or URL but tags would (if defined)
+      // Since tags is undefined, ?? [] kicks in and returns [] — resource not found, no crash
+      component.searchQuery = 'nosuchtag';
+      expect(component.searchResults).toHaveLength(0);
+    });
+  });
+
+  // ── showAddDialog ────────────────────────────────────────────
+
+  it('showAddDialog is false initially', () => {
+    expect(component.showAddDialog).toBe(false);
+  });
+
+  // ── onTypeChange ─────────────────────────────────────────────
+
+  it('onTypeChange clears the oEmbed thumbnail', () => {
+    (component as any)._oEmbedThumbnail.set('https://img.youtube.com/vi/test/0.jpg');
+    component.onTypeChange();
+    expect(component.oEmbedThumbnail()).toBeNull();
+  });
+
+  // ── libraryLoading error path ────────────────────────────────
+
+  it('sets libraryLoading to false when getResources errors', async () => {
+    jest.clearAllMocks();
+    const err$ = new Subject<Resource[]>();
+    mockResourceService.getResources.mockReturnValue(err$.asObservable());
 
     fixture = TestBed.createComponent(SessionResourcePickerComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
 
-    component.labelFilter = 'blues';
-    expect(component.filteredResources.map(r => r.id)).toEqual(['1']);
+    expect(component.libraryLoading()).toBe(true);
+
+    err$.error(new Error('network error'));
+    fixture.detectChanges();
+
+    expect(component.libraryLoading()).toBe(false);
   });
 
-  it('onTypeChange clears the oEmbed thumbnail', () => {
-    (component as any)._oEmbedThumbnail.set('https://img.youtube.com/vi/test/0.jpg');
-    component.onTypeChange();
+  // ── onUrlBlur ────────────────────────────────────────────────
+
+  it('onUrlBlur returns early when newType is not youtube', async () => {
+    const fetchSpy = jest.spyOn(youtube, 'fetchYouTubeOEmbed');
+    component.newType = 'pdf';
+    component.newUrl = 'https://example.com/tab.pdf';
+    await component.onUrlBlur();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('onUrlBlur returns early when url is empty', async () => {
+    const fetchSpy = jest.spyOn(youtube, 'fetchYouTubeOEmbed');
+    component.newType = 'youtube';
+    component.newUrl = '';
+    await component.onUrlBlur();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('onUrlBlur returns early when url changes during fetch', async () => {
+    const ytUrl = 'https://www.youtube.com/watch?v=abc';
+    (youtube.fetchYouTubeOEmbed as jest.Mock).mockImplementation(async () => {
+      component.newUrl = 'https://www.youtube.com/watch?v=changed';
+      return { title: 'Rick', thumbnailUrl: 'https://img' };
+    });
+
+    component.newType = 'youtube';
+    component.newUrl = ytUrl;
+    component.newLabel = '';
+    await component.onUrlBlur();
+
+    expect(component.newLabel).toBe('');
+    expect(component.oEmbedThumbnail()).toBeNull();
+  });
+
+  it('onUrlBlur sets label from oembed.title when label is empty', async () => {
+    (youtube.fetchYouTubeOEmbed as jest.Mock).mockResolvedValue({
+      title: 'Rick Astley',
+      thumbnailUrl: 'https://img.youtube.com/vi/abc/0.jpg',
+    });
+
+    component.newType = 'youtube';
+    component.newUrl = 'https://www.youtube.com/watch?v=abc';
+    component.newLabel = '';
+    await component.onUrlBlur();
+
+    expect(component.newLabel).toBe('Rick Astley');
+    expect(component.oEmbedThumbnail()).toBe('https://img.youtube.com/vi/abc/0.jpg');
+  });
+
+  it('onUrlBlur does not overwrite existing label', async () => {
+    (youtube.fetchYouTubeOEmbed as jest.Mock).mockResolvedValue({
+      title: 'Rick Astley',
+      thumbnailUrl: 'https://img.youtube.com/vi/abc/0.jpg',
+    });
+
+    component.newType = 'youtube';
+    component.newUrl = 'https://www.youtube.com/watch?v=abc';
+    component.newLabel = 'My custom label';
+    await component.onUrlBlur();
+
+    expect(component.newLabel).toBe('My custom label');
+  });
+
+  it('onUrlBlur sets thumbnail to null when oembed.thumbnailUrl is empty', async () => {
+    (youtube.fetchYouTubeOEmbed as jest.Mock).mockResolvedValue({
+      title: 'Some video',
+      thumbnailUrl: '',
+    });
+
+    component.newType = 'youtube';
+    component.newUrl = 'https://www.youtube.com/watch?v=abc';
+    component.newLabel = 'Existing';
+    await component.onUrlBlur();
+
+    expect(component.oEmbedThumbnail()).toBeNull();
+  });
+
+  it('onUrlBlur does nothing when oembed is null', async () => {
+    (youtube.fetchYouTubeOEmbed as jest.Mock).mockResolvedValue(null);
+
+    component.newType = 'youtube';
+    component.newUrl = 'https://www.youtube.com/watch?v=abc';
+    component.newLabel = 'Existing';
+    await component.onUrlBlur();
+
+    expect(component.newLabel).toBe('Existing');
     expect(component.oEmbedThumbnail()).toBeNull();
   });
 });

--- a/src/app/features/session/session-resource-picker/session-resource-picker.component.ts
+++ b/src/app/features/session/session-resource-picker/session-resource-picker.component.ts
@@ -1,13 +1,14 @@
-import { Component, DestroyRef, EventEmitter, Output, inject, signal, computed } from '@angular/core';
+import { Component, DestroyRef, EventEmitter, Output, inject, signal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormsModule } from '@angular/forms';
 import { AutoComplete } from 'primeng/autocomplete';
 import { ButtonModule } from 'primeng/button';
+import { Dialog } from 'primeng/dialog';
 import { InputTextModule } from 'primeng/inputtext';
-import { Listbox } from 'primeng/listbox';
 import { Message } from 'primeng/message';
 import { Select } from 'primeng/select';
 import { Skeleton } from 'primeng/skeleton';
+import { TableModule } from 'primeng/table';
 import { ResourceService } from '../../../services/resource.service';
 import { Resource } from '../../../models/resource';
 import { SessionResource } from '../../../models/session-resource';
@@ -18,7 +19,7 @@ type ResourceType = 'youtube' | 'pdf' | 'chord-sheet' | 'custom';
 @Component({
   selector: 'app-session-resource-picker',
   standalone: true,
-  imports: [FormsModule, AutoComplete, ButtonModule, InputTextModule, Listbox, Message, Select, Skeleton],
+  imports: [FormsModule, AutoComplete, ButtonModule, Dialog, InputTextModule, Message, Select, Skeleton, TableModule],
   templateUrl: './session-resource-picker.component.html',
 })
 export class SessionResourcePickerComponent {
@@ -27,34 +28,34 @@ export class SessionResourcePickerComponent {
 
   @Output() resourceAdded = new EventEmitter<Omit<SessionResource, 'id' | 'pinnedAt'>>();
 
-  // Library state
   private _allResources = signal<Resource[]>([]);
   private _libraryLoading = signal(true);
 
   readonly libraryLoading = this._libraryLoading.asReadonly();
-  readonly allResources = this._allResources.asReadonly();
 
-  // Filter state (plain properties — template ngModel binds directly)
-  labelFilter = '';
-  tagFilter: string[] = [];
+  // Search
+  searchQuery = '';
 
-  get filteredResources(): Resource[] {
-    const label = this.labelFilter.toLowerCase();
-    const tags = this.tagFilter;
+  get searchResults(): Resource[] {
+    const q = this.searchQuery.toLowerCase().trim();
+    if (q.length < 3) return [];
     return this._allResources()
-      .filter(r => (label ? r.label.toLowerCase().includes(label) : true))
-      .filter(r => (tags.length ? tags.every(t => r.tags?.includes(t)) : true))
-      .slice(0, 50);
+      .filter(r =>
+        r.label.toLowerCase().includes(q) ||
+        r.url.toLowerCase().includes(q) ||
+        (r.tags ?? []).some(t => t.toLowerCase().includes(q))
+      )
+      .slice(0, 20);
   }
 
-  // Add-new form state
+  // Add-new dialog
+  showAddDialog = false;
   newType: ResourceType = 'youtube';
   newUrl = '';
   newLabel = '';
   newTags: string[] = [];
   tagSuggestions: string[] = [];
 
-  // oEmbed state
   private _oEmbedLoading = signal(false);
   private _oEmbedThumbnail = signal<string | null>(null);
 
@@ -103,7 +104,7 @@ export class SessionResourcePickerComponent {
 
     const oembed = await fetchYouTubeOEmbed(url);
 
-    if (this.newUrl !== urlAtFetchStart) return; // stale response guard
+    if (this.newUrl !== urlAtFetchStart) return;
 
     this._oEmbedLoading.set(false);
     if (oembed) {
@@ -131,6 +132,7 @@ export class SessionResourcePickerComponent {
     this.newLabel = '';
     this.newTags = [];
     this._oEmbedThumbnail.set(null);
+    this.showAddDialog = false;
   }
 
   onLibrarySelect(resource: Resource): void {

--- a/src/app/features/session/session.component.spec.ts
+++ b/src/app/features/session/session.component.spec.ts
@@ -160,6 +160,16 @@ describe('SessionComponent (template-driven behaviors)', () => {
       const { fixture } = createFixtureWithStatus('During');
       expect(fixture.debugElement.query(By.css('#resourcesSection'))).toBeNull();
     });
+
+    it('timer increments elapsedSeconds every second', fakeAsync(() => {
+      const { cmp } = createFixtureWithStatus('During');
+      expect(cmp.elapsedSeconds()).toBe(0);
+      tick(1000);
+      expect(cmp.elapsedSeconds()).toBe(1);
+      tick(2000);
+      expect(cmp.elapsedSeconds()).toBe(3);
+      cmp.stopTimer();
+    }));
   });
 
   describe('AFTER state', () => {
@@ -254,6 +264,30 @@ describe('SessionComponent (template-driven behaviors)', () => {
       });
       expect(cmp.saving()).toBe(false);
       expect(cmp.loading()).toBe(false);
+      expect(navigate).toHaveBeenCalledWith(['/app']);
+    });
+
+    it('calls saveResources when there are pending resources', async () => {
+      const fixture = TestBed.createComponent(SessionComponent);
+      const cmp = fixture.componentInstance;
+
+      const navigate = jest.fn();
+      (cmp as any).router = { navigate };
+
+      const svc = TestBed.inject(SessionService) as any;
+      jest.spyOn(svc, 'create').mockResolvedValue('sess-with-resources');
+
+      const resSvc = TestBed.inject(ResourceService) as any;
+      const saveSpy = jest.spyOn(resSvc, 'saveResources').mockResolvedValue(undefined);
+
+      primeValidForm(cmp);
+      cmp.onResourceAdded({ type: 'youtube', url: 'https://www.youtube.com/watch?v=abc', label: 'Lesson' });
+
+      await cmp.onSubmit();
+
+      expect(saveSpy).toHaveBeenCalledWith('sess-with-resources', expect.arrayContaining([
+        expect.objectContaining({ url: 'https://www.youtube.com/watch?v=abc' }),
+      ]));
       expect(navigate).toHaveBeenCalledWith(['/app']);
     });
 

--- a/src/app/features/songs/songs.component.spec.ts
+++ b/src/app/features/songs/songs.component.spec.ts
@@ -38,4 +38,14 @@ describe('SongsComponent', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  it('onRowSelect navigates to /app/songDetail/{id}', () => {
+    component.onRowSelect({ data: { id: 'song-42' } });
+    expect(mockRouter.navigate).toHaveBeenCalledWith(['/app', 'songDetail', 'song-42']);
+  });
+
+  it('addSong navigates to /app/newSong', () => {
+    component.addSong();
+    expect(mockRouter.navigate).toHaveBeenCalledWith(['/app', 'newSong']);
+  });
 });

--- a/src/app/services/resource.service.spec.ts
+++ b/src/app/services/resource.service.spec.ts
@@ -1,15 +1,12 @@
-jest.mock('@angular/fire/firestore', () => ({
-  Firestore: class {},
-  collectionData: jest.fn(),
-}));
-
-jest.mock('firebase/firestore', () => {
+// All Firestore functions are now imported from @angular/fire/firestore (not firebase/firestore).
+jest.mock('@angular/fire/firestore', () => {
   const withConverter = jest.fn().mockReturnThis();
   const collection = jest.fn(() => ({ withConverter, _isMock: true }));
   const doc = jest.fn((db: any, path: string) => ({ _path: path }));
 
   return {
-    getFirestore: jest.fn(() => ({})),
+    Firestore: class {},
+    collectionData: jest.fn(),
     collection,
     doc,
     query: jest.fn((q: any) => q),
@@ -30,7 +27,6 @@ import { of } from 'rxjs';
 import { Auth } from '@angular/fire/auth';
 
 import * as afs from '@angular/fire/firestore';
-import * as fbfs from 'firebase/firestore';
 
 import { ResourceService } from './resource.service';
 
@@ -58,9 +54,9 @@ describe('ResourceService', () => {
     it('queries users/{uid}/resources ordered by createdAt desc, limit 200', () => {
       service.getResources();
 
-      expect(fbfs.collection).toHaveBeenCalledWith(expect.anything(), 'users/u1/resources');
-      expect(fbfs.orderBy).toHaveBeenCalledWith('createdAt', 'desc');
-      expect(fbfs.limit).toHaveBeenCalledWith(200);
+      expect(afs.collection).toHaveBeenCalledWith(expect.anything(), 'users/u1/resources');
+      expect(afs.orderBy).toHaveBeenCalledWith('createdAt', 'desc');
+      expect(afs.limit).toHaveBeenCalledWith(200);
       expect(afs.collectionData).toHaveBeenCalledWith(expect.anything(), { idField: 'id' });
     });
 
@@ -74,11 +70,11 @@ describe('ResourceService', () => {
     it('queries the session resources subcollection ordered by pinnedAt asc', () => {
       service.getSessionResources('sess1');
 
-      expect(fbfs.collection).toHaveBeenCalledWith(
+      expect(afs.collection).toHaveBeenCalledWith(
         expect.anything(),
         'users/u1/sessions/sess1/resources'
       );
-      expect(fbfs.orderBy).toHaveBeenCalledWith('pinnedAt', 'asc');
+      expect(afs.orderBy).toHaveBeenCalledWith('pinnedAt', 'asc');
     });
   });
 
@@ -91,28 +87,24 @@ describe('ResourceService', () => {
     };
 
     it('creates a global library doc and a session pin for a new resource (no dedup hit)', async () => {
-      (fbfs.getDocs as jest.Mock).mockResolvedValue({ empty: true, docs: [] });
+      (afs.getDocs as jest.Mock).mockResolvedValue({ empty: true, docs: [] });
 
       await service.saveResources('sess1', [newResource]);
 
-      // dedup query ran
-      expect(fbfs.getDocs).toHaveBeenCalledTimes(1);
-      // addDoc called twice: global lib + session pin
-      expect(fbfs.addDoc).toHaveBeenCalledTimes(2);
+      expect(afs.getDocs).toHaveBeenCalledTimes(1);
+      expect(afs.addDoc).toHaveBeenCalledTimes(2);
     });
 
     it('reuses existing global doc when URL dedup finds a match', async () => {
-      (fbfs.getDocs as jest.Mock).mockResolvedValue({
+      (afs.getDocs as jest.Mock).mockResolvedValue({
         empty: false,
         docs: [{ id: 'existing-id' }],
       });
 
       await service.saveResources('sess1', [newResource]);
 
-      // no new global lib doc created
-      expect(fbfs.addDoc).toHaveBeenCalledTimes(1); // only session pin
-      // touchResource called via updateDoc
-      expect(fbfs.updateDoc).toHaveBeenCalledTimes(1);
+      expect(afs.addDoc).toHaveBeenCalledTimes(1);
+      expect(afs.updateDoc).toHaveBeenCalledTimes(1);
     });
 
     it('touches an existing resource (has resourceId) and writes session pin', async () => {
@@ -120,20 +112,30 @@ describe('ResourceService', () => {
 
       await service.saveResources('sess1', [existingResource]);
 
-      // no dedup query needed
-      expect(fbfs.getDocs).not.toHaveBeenCalled();
-      // updateDoc from touchResource + addDoc for session pin
-      expect(fbfs.updateDoc).toHaveBeenCalledTimes(1);
-      expect(fbfs.addDoc).toHaveBeenCalledTimes(1);
+      expect(afs.getDocs).not.toHaveBeenCalled();
+      expect(afs.updateDoc).toHaveBeenCalledTimes(1);
+      expect(afs.addDoc).toHaveBeenCalledTimes(1);
     });
 
     it('sets pinnedAt via serverTimestamp on the session pin', async () => {
-      (fbfs.getDocs as jest.Mock).mockResolvedValue({ empty: true, docs: [] });
+      (afs.getDocs as jest.Mock).mockResolvedValue({ empty: true, docs: [] });
 
       await service.saveResources('sess1', [newResource]);
 
-      const pinCall = (fbfs.addDoc as jest.Mock).mock.calls[1];
+      const pinCall = (afs.addDoc as jest.Mock).mock.calls[1];
       expect(pinCall[1]).toMatchObject({ pinnedAt: 'server-ts' });
+    });
+
+    it('defaults tags to [] when resource.tags is undefined (new resource path)', async () => {
+      const resourceWithoutTags = { type: 'youtube' as const, url: 'https://www.youtube.com/watch?v=abc', label: 'Test' };
+      (afs.getDocs as jest.Mock).mockResolvedValue({ empty: true, docs: [] });
+
+      await service.saveResources('sess1', [resourceWithoutTags]);
+
+      const globalDocCall = (afs.addDoc as jest.Mock).mock.calls[0];
+      expect(globalDocCall[1]).toMatchObject({ tags: [] });
+      const pinCall = (afs.addDoc as jest.Mock).mock.calls[1];
+      expect(pinCall[1]).toMatchObject({ tags: [] });
     });
   });
 
@@ -141,8 +143,8 @@ describe('ResourceService', () => {
     it('calls deleteDoc on users/{uid}/resources/{id}', async () => {
       await service.deleteResource('res1');
 
-      expect(fbfs.doc).toHaveBeenCalledWith(expect.anything(), 'users/u1/resources/res1');
-      expect(fbfs.deleteDoc).toHaveBeenCalledTimes(1);
+      expect(afs.doc).toHaveBeenCalledWith(expect.anything(), 'users/u1/resources/res1');
+      expect(afs.deleteDoc).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -150,8 +152,8 @@ describe('ResourceService', () => {
     it('calls updateDoc with label and tags changes', async () => {
       await service.updateResource('res1', { label: 'Updated', tags: ['rock'] });
 
-      expect(fbfs.doc).toHaveBeenCalledWith(expect.anything(), 'users/u1/resources/res1');
-      expect(fbfs.updateDoc).toHaveBeenCalledWith(
+      expect(afs.doc).toHaveBeenCalledWith(expect.anything(), 'users/u1/resources/res1');
+      expect(afs.updateDoc).toHaveBeenCalledWith(
         expect.anything(),
         { label: 'Updated', tags: ['rock'] }
       );
@@ -162,8 +164,8 @@ describe('ResourceService', () => {
     it('increments useCount and sets lastUsedAt to serverTimestamp', async () => {
       await service.touchResource('res1');
 
-      expect(fbfs.doc).toHaveBeenCalledWith(expect.anything(), 'users/u1/resources/res1');
-      expect(fbfs.updateDoc).toHaveBeenCalledWith(expect.anything(), {
+      expect(afs.doc).toHaveBeenCalledWith(expect.anything(), 'users/u1/resources/res1');
+      expect(afs.updateDoc).toHaveBeenCalledWith(expect.anything(), {
         useCount: { _increment: 1 },
         lastUsedAt: 'server-ts',
       });

--- a/src/app/services/resource.service.ts
+++ b/src/app/services/resource.service.ts
@@ -1,8 +1,7 @@
 import { Injectable } from '@angular/core';
-import { Firestore, collectionData } from '@angular/fire/firestore';
-import { Auth } from '@angular/fire/auth';
 import {
-  getFirestore,
+  Firestore,
+  collectionData,
   collection,
   doc,
   query,
@@ -15,7 +14,8 @@ import {
   deleteDoc,
   serverTimestamp,
   increment,
-} from 'firebase/firestore';
+} from '@angular/fire/firestore';
+import { Auth } from '@angular/fire/auth';
 import { Observable } from 'rxjs';
 import { Resource } from '../models/resource';
 import { SessionResource } from '../models/session-resource';
@@ -33,7 +33,7 @@ export class ResourceService {
 
   getResources(): Observable<Resource[]> {
     const uid = this.uid();
-    const db = getFirestore();
+    const db = this.fs;
     const col = collection(db, `users/${uid}/resources`).withConverter(resourceConverter);
     const q = query(col, orderBy('createdAt', 'desc'), limit(200));
     return collectionData(q, { idField: 'id' }) as unknown as Observable<Resource[]>;
@@ -41,7 +41,7 @@ export class ResourceService {
 
   getSessionResources(sessionId: string): Observable<SessionResource[]> {
     const uid = this.uid();
-    const db = getFirestore();
+    const db = this.fs;
     const col = collection(db, `users/${uid}/sessions/${sessionId}/resources`).withConverter(
       sessionResourceConverter
     );
@@ -54,7 +54,7 @@ export class ResourceService {
     resources: Omit<SessionResource, 'id' | 'pinnedAt'>[]
   ): Promise<void> {
     const uid = this.uid();
-    const db = getFirestore();
+    const db = this.fs;
 
     for (const resource of resources) {
       let globalResourceId: string;
@@ -107,7 +107,7 @@ export class ResourceService {
 
   async deleteResource(resourceId: string): Promise<void> {
     const uid = this.uid();
-    const db = getFirestore();
+    const db = this.fs;
     await deleteDoc(doc(db, `users/${uid}/resources/${resourceId}`));
   }
 
@@ -116,13 +116,13 @@ export class ResourceService {
     changes: Partial<Pick<Resource, 'label' | 'tags'>>
   ): Promise<void> {
     const uid = this.uid();
-    const db = getFirestore();
+    const db = this.fs;
     await updateDoc(doc(db, `users/${uid}/resources/${resourceId}`), changes);
   }
 
   async touchResource(resourceId: string): Promise<void> {
     const uid = this.uid();
-    const db = getFirestore();
+    const db = this.fs;
     await updateDoc(doc(db, `users/${uid}/resources/${resourceId}`), {
       useCount: increment(1),
       lastUsedAt: serverTimestamp(),

--- a/src/app/shells/app-shell.component.spec.ts
+++ b/src/app/shells/app-shell.component.spec.ts
@@ -108,4 +108,13 @@ describe('AppShellComponent', () => {
     expect(signOut).toHaveBeenCalledWith(auth);
     expect(navigateSpy).toHaveBeenCalledWith(['/']);
   });
+
+  it('toggleSidebar flips collapsed signal each call', () => {
+    const cmp = fixture.componentInstance;
+    expect(cmp.collapsed()).toBe(false);
+    cmp.toggleSidebar();
+    expect(cmp.collapsed()).toBe(true);
+    cmp.toggleSidebar();
+    expect(cmp.collapsed()).toBe(false);
+  });
 });

--- a/src/app/shells/public-shell.component.spec.ts
+++ b/src/app/shells/public-shell.component.spec.ts
@@ -1,0 +1,25 @@
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { PublicShellComponent } from './public-shell.component';
+
+describe('PublicShellComponent', () => {
+  let fixture: ComponentFixture<PublicShellComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [PublicShellComponent],
+      providers: [provideRouter([])],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(PublicShellComponent);
+    fixture.detectChanges();
+  });
+
+  it('creates the component', () => {
+    expect(fixture.componentInstance).toBeTruthy();
+  });
+
+  it('currentYear equals the current calendar year', () => {
+    expect(fixture.componentInstance.currentYear).toBe(new Date().getFullYear());
+  });
+});

--- a/src/app/storage/popular-music.converters.spec.ts
+++ b/src/app/storage/popular-music.converters.spec.ts
@@ -14,6 +14,12 @@ describe('Popular music converters', () => {
       expect('id' in (doc as any)).toBe(false);
     });
 
+    it('toFirestore falls back to name.toLowerCase() when sortName is undefined', () => {
+      const artist = { name: 'The Beatles' } as PopularArtist;
+      const doc = popularArtistConverter.toFirestore(artist);
+      expect(doc).toEqual({ name: 'The Beatles', sortName: 'the beatles' });
+    });
+
     it('fromFirestore returns { id, ...data }', () => {
       const snap = { id: 'the-beatles', data: () => ({ name: 'The Beatles', sortName: 'the beatles' }) } as any;
       const result = popularArtistConverter.fromFirestore(snap);
@@ -29,6 +35,12 @@ describe('Popular music converters', () => {
       expect('id' in (doc as any)).toBe(false);
     });
 
+    it('toFirestore falls back to title.toLowerCase() when sortTitle is undefined', () => {
+      const album = { title: 'Abbey Road', artist: 'The Beatles' } as PopularAlbum;
+      const doc = popularAlbumConverter.toFirestore(album);
+      expect(doc).toEqual({ title: 'Abbey Road', artist: 'The Beatles', sortTitle: 'abbey road' });
+    });
+
     it('fromFirestore returns { id, ...data }', () => {
       const snap = { id: 'abbey-road', data: () => ({ title: 'Abbey Road', artist: 'The Beatles', sortTitle: 'abbey road' }) } as any;
       const result = popularAlbumConverter.fromFirestore(snap);
@@ -42,6 +54,12 @@ describe('Popular music converters', () => {
       const doc = popularSongConverter.toFirestore(song);
       expect(doc).toEqual({ title: 'Blackbird', artist: 'The Beatles', sortTitle: 'blackbird' });
       expect('id' in (doc as any)).toBe(false);
+    });
+
+    it('toFirestore falls back to title.toLowerCase() when sortTitle is undefined', () => {
+      const song = { title: 'Blackbird', artist: 'The Beatles' } as PopularSong;
+      const doc = popularSongConverter.toFirestore(song);
+      expect(doc).toEqual({ title: 'Blackbird', artist: 'The Beatles', sortTitle: 'blackbird' });
     });
 
     it('fromFirestore returns { id, ...data }', () => {

--- a/src/app/utils/youtube.spec.ts
+++ b/src/app/utils/youtube.spec.ts
@@ -32,6 +32,14 @@ describe('extractYouTubeEmbedUrl', () => {
   it('returns null for a YouTube URL with no video ID', () => {
     expect(extractYouTubeEmbedUrl('https://www.youtube.com/watch')).toBeNull();
   });
+
+  it('returns null for a /shorts/ URL with no video ID', () => {
+    expect(extractYouTubeEmbedUrl('https://www.youtube.com/shorts/')).toBeNull();
+  });
+
+  it('returns null for a youtu.be URL with empty path', () => {
+    expect(extractYouTubeEmbedUrl('https://youtu.be/')).toBeNull();
+  });
 });
 
 describe('fetchYouTubeOEmbed', () => {


### PR DESCRIPTION
## Summary

- **Firebase fixes**: Moved all Firestore imports to `@angular/fire/firestore` to resolve "No Firebase App '[DEFAULT]'" crash on `/app/newSession`; wrapped all Auth calls in `runInInjectionContext` to fix "Calling Firebase APIs outside of an Injection context" warnings
- **Dashboard navigation**: Added a `Dashboard` button next to the `Back` button on the session detail screen; fixed ngtsc(2533) null-safety errors in the template using `@let` narrowing
- **Resource picker redesign**: Replaced the "Your Library" listbox with a searchable text field (results appear after 3+ characters) and moved "Add New" into a modal dialog
- **Test coverage**: Increased branch coverage from ~59% to 96.69% across 357 tests — new specs for carousel converters, `onUrlBlur`, timer tick, `saveResources` path, `hasError` computed, and more

## Test plan

- [ ] Run `npx jest --coverage` — all 357 tests should pass with ≥96% branch coverage
- [ ] Navigate to `/app/newSession` — no Firebase errors in the console, resource picker loads
- [ ] Search for existing resources — results appear after typing 3+ characters
- [ ] Click "Add New Resource" — modal dialog opens with form fields
- [ ] On a session detail page, confirm both **Back** and **Dashboard** buttons are present and navigate correctly
- [ ] Sign in / sign out flows work without injection-context warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)